### PR TITLE
be more conservative about branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "1.1.x-dev"
+			"dev-master": "2.0.x-dev"
 		}
 	}
 }


### PR DESCRIPTION
to avoid users using branch alias to mess their dependencies in the long term, it would be desirable that the branch alias stays close to the targeted release lest conflict nightmares and wrong tracking of where some projects were arise.
