### PR TITLE
Do not return stuff on unserialize

### DIFF
--- a/src/DiffOp/Diff/Diff.php
+++ b/src/DiffOp/Diff/Diff.php
@@ -164,8 +164,6 @@ class Diff extends \ArrayObject implements DiffOp {
 	 * @since 0.1
 	 *
 	 * @param string $serialization
-	 *
-	 * @return array
 	 */
 	public function unserialize( $serialization ) {
 		$serializationData = unserialize( $serialization );
@@ -189,8 +187,6 @@ class Diff extends \ArrayObject implements DiffOp {
 		elseif ( $this instanceof ListDiff ) {
 			$this->isAssociative = false;
 		}
-
-		return $serializationData;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #14. This is the only place in Diff where `unserialize` returns something.

I did some regex searches in our code base and could not find a place where `unserialize` is called and expected to have a return value (I tried to search for stuff like `... = ...->unserialize( ... )` as well as `...( ...->unserialize( ... )`).

This is obviously not urgent at all. Please double-check.

Also see https://github.com/wmde/WikibaseDataModel/pull/220.
