### PR TITLE
Allow running phpmd separately

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,12 +48,18 @@
 			"phpunit"
 		],
 		"cs": [
-			"vendor/bin/phpcs src/* tests/* --standard=phpcs.xml --extensions=php -sp",
-			"vendor/bin/phpmd src/ text phpmd.xml"
+			"composer phpcs",
+			"composer phpmd"
 		],
 		"ci": [
 			"composer test",
 			"composer cs"
+		],
+		"phpcs": [
+			"vendor/bin/phpcs src/* tests/* --standard=phpcs.xml --extensions=php -sp"
+		],
+		"phpmd": [
+			"vendor/bin/phpmd src/ text phpmd.xml"
 		]
 	}
 }


### PR DESCRIPTION
I played around with PHPMD and am a bit disappointed. It's not possible to set a number like "this rule is allowed to be broken x times in the legacy code base, but report any new exception".
* Added ~~`composer md`~~ `composer phpcs` and `composer phpmd` commands.
* ~~`composer cs` does not execute PHPMD any more, but `composer ci` still does~~.
* ~~Re-enabled all rules with limits that are exactly as high as the current code is~~ (see #36).
* ~~Re-wrote one method because of the unused variables rule~~ (reverted).