### PR TITLE
Make @deprecated tags more descriptive

### DIFF
--- a/src/DiffOp/Diff/ListDiff.php
+++ b/src/DiffOp/Diff/ListDiff.php
@@ -10,7 +10,7 @@ namespace Diff\DiffOp\Diff;
  * Soft deprecated since 0.4, just use Diff
  *
  * @since 0.1
- * @deprecated since 0.5
+ * @deprecated since 0.5, just use Diff instead
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >

--- a/src/DiffOp/Diff/MapDiff.php
+++ b/src/DiffOp/Diff/MapDiff.php
@@ -11,7 +11,7 @@ namespace Diff\DiffOp\Diff;
  * Soft deprecated since 0.4, just use Diff
  *
  * @since 0.1
- * @deprecated since 0.5
+ * @deprecated since 0.5, just use Diff instead
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >

--- a/src/Differ/ListDiffer.php
+++ b/src/Differ/ListDiffer.php
@@ -28,7 +28,7 @@ class ListDiffer implements Differ {
 	 * This makes use of @see array_diff
 	 *
 	 * @since 0.4
-	 * @deprecated since 0.8
+	 * @deprecated since 0.8, use new NativeArrayComparer() instead
 	 */
 	const MODE_NATIVE = 0;
 
@@ -37,7 +37,7 @@ class ListDiffer implements Differ {
 	 * This makes use of @see ListDiffer::strictDiff
 	 *
 	 * @since 0.4
-	 * @deprecated since 0.8
+	 * @deprecated since 0.8, use null instead
 	 */
 	const MODE_STRICT = 1;
 

--- a/tests/phpunit/DiffOp/Diff/ListDiffTest.php
+++ b/tests/phpunit/DiffOp/Diff/ListDiffTest.php
@@ -2,6 +2,7 @@
 
 namespace Diff\Tests\DiffOp\Diff;
 
+use Diff\ArrayComparer\NativeArrayComparer;
 use Diff\Differ\ListDiffer;
 use Diff\DiffOp\Diff\Diff;
 use Diff\DiffOp\DiffOpAdd;
@@ -134,7 +135,7 @@ class ListDiffTest extends DiffOpTest {
 	 * @dataProvider newFromArraysProvider
 	 */
 	public function testNewFromArrays( array $from, array $to, array $additions, array $removals ) {
-		$differ = new ListDiffer( ListDiffer::MODE_NATIVE );
+		$differ = new ListDiffer( new NativeArrayComparer() );
 
 		$diff = new Diff( $differ->doDiff( $from, $to ), false );
 

--- a/tests/phpunit/Differ/ListDifferTest.php
+++ b/tests/phpunit/Differ/ListDifferTest.php
@@ -2,6 +2,7 @@
 
 namespace Diff\Tests\Differ;
 
+use Diff\ArrayComparer\NativeArrayComparer;
 use Diff\Differ\Differ;
 use Diff\Differ\ListDiffer;
 use Diff\DiffOp\DiffOpAdd;
@@ -206,7 +207,7 @@ class ListDifferTest extends DiffTestCase {
 	 * @dataProvider toDiffNativeProvider
 	 */
 	public function testDoNativeDiff( $old, $new, $expected, $message = '' ) {
-		$this->doTestDiff( new ListDiffer( ListDiffer::MODE_NATIVE ), $old, $new, $expected, $message );
+		$this->doTestDiff( new ListDiffer( new NativeArrayComparer() ), $old, $new, $expected, $message );
 	}
 
 	private function doTestDiff( Differ $differ, $old, $new, $expected, $message ) {

--- a/tests/phpunit/Differ/MapDifferTest.php
+++ b/tests/phpunit/Differ/MapDifferTest.php
@@ -2,6 +2,7 @@
 
 namespace Diff\Tests\Differ;
 
+use Diff\ArrayComparer\NativeArrayComparer;
 use Diff\Differ\Differ;
 use Diff\Differ\ListDiffer;
 use Diff\Differ\MapDiffer;
@@ -159,7 +160,7 @@ class MapDifferTest extends DiffTestCase {
 
 		$argLists[] = array( $old, $new, $expected,
 			'Setting a non-default Differ for non-associative diffs should work',
-			true, new ListDiffer( ListDiffer::MODE_NATIVE ) );
+			true, new ListDiffer( new NativeArrayComparer() ) );
 
 
 		$old = array( 'a' => array( 42 ), 1, array( 'a' => 'b', 5 ), 'bah' => array( 'foo' => 'bar' ) );


### PR DESCRIPTION
This patch also replaces deprecated constants in 3 places in tests. Please double check that I'm not accidentally changing tests that do have the purpose of covering these deprecated constants.