### PR TITLE
Favor shortcut "bool" in PHPDoc tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The `ValueComparer` interface contains one method:
  * @param mixed $firstValue
  * @param mixed $secondValue
  *
- * @return boolean
+ * @return bool
  */
 public function valuesAreEqual( $firstValue, $secondValue );
 ```

--- a/src/Comparer/ValueComparer.php
+++ b/src/Comparer/ValueComparer.php
@@ -18,7 +18,7 @@ interface ValueComparer {
 	 * @param mixed $firstValue
 	 * @param mixed $secondValue
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function valuesAreEqual( $firstValue, $secondValue );
 

--- a/src/DiffOp/AtomicDiffOp.php
+++ b/src/DiffOp/AtomicDiffOp.php
@@ -30,7 +30,7 @@ abstract class AtomicDiffOp implements DiffOp {
 	 *
 	 * @since 0.1
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function isAtomic() {
 		return true;

--- a/src/DiffOp/Diff/Diff.php
+++ b/src/DiffOp/Diff/Diff.php
@@ -21,7 +21,7 @@ use InvalidArgumentException;
 class Diff extends \ArrayObject implements DiffOp {
 
 	/**
-	 * @var boolean|null
+	 * @var bool|null
 	 */
 	private $isAssociative = null;
 
@@ -48,7 +48,7 @@ class Diff extends \ArrayObject implements DiffOp {
 	 * @since 0.1
 	 *
 	 * @param DiffOp[] $operations
-	 * @param boolean|null $isAssociative
+	 * @param bool|null $isAssociative
 	 *
 	 * @throws InvalidArgumentException
 	 */
@@ -129,7 +129,7 @@ class Diff extends \ArrayObject implements DiffOp {
 	 * @param integer|string $index
 	 * @param mixed $value
 	 *
-	 * @return boolean
+	 * @return bool
 	 * @throws InvalidArgumentException
 	 */
 	private function preSetElement( $index, $value ) {
@@ -245,7 +245,7 @@ class Diff extends \ArrayObject implements DiffOp {
 	 *
 	 * @since 0.1
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function isAtomic() {
 		return false;
@@ -305,7 +305,7 @@ class Diff extends \ArrayObject implements DiffOp {
 	 *
 	 * @since 0.4
 	 *
-	 * @return boolean|null
+	 * @return bool|null
 	 */
 	public function isAssociative() {
 		return $this->isAssociative;
@@ -318,7 +318,7 @@ class Diff extends \ArrayObject implements DiffOp {
 	 *
 	 * @since 0.4
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function looksAssociative() {
 		return $this->isAssociative === null ? $this->hasAssociativeOperations() : $this->isAssociative;
@@ -330,7 +330,7 @@ class Diff extends \ArrayObject implements DiffOp {
 	 *
 	 * @since 0.4
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function hasAssociativeOperations() {
 		return !empty( $this->typePointers['change'] )
@@ -409,7 +409,7 @@ class Diff extends \ArrayObject implements DiffOp {
 	 *
 	 * @param mixed $value
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	private function hasValidType( $value ) {
 		$class = $this->getObjectType();
@@ -471,7 +471,7 @@ class Diff extends \ArrayObject implements DiffOp {
 	 *
 	 * @since 0.1
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function isEmpty() {
 		return $this->count() === 0;

--- a/src/DiffOp/DiffOp.php
+++ b/src/DiffOp/DiffOp.php
@@ -30,7 +30,7 @@ interface DiffOp extends \Serializable, \Countable {
 	 *
 	 * @since 0.1
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function isAtomic();
 

--- a/src/Differ/MapDiffer.php
+++ b/src/Differ/MapDiffer.php
@@ -22,7 +22,7 @@ use LogicException;
 class MapDiffer implements Differ {
 
 	/**
-	 * @var boolean
+	 * @var bool
 	 */
 	private $recursively;
 
@@ -159,7 +159,7 @@ class MapDiffer implements Differ {
 	 *
 	 * @param array $array
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	private function isAssociative( array $array ) {
 		foreach ( $array as $key => $value ) {

--- a/src/Patcher/ThrowingPatcher.php
+++ b/src/Patcher/ThrowingPatcher.php
@@ -19,14 +19,14 @@ use Diff\DiffOp\Diff\Diff;
 abstract class ThrowingPatcher implements PreviewablePatcher {
 
 	/**
-	 * @var boolean
+	 * @var bool
 	 */
 	private $throwErrors;
 
 	/**
 	 * @since 0.4
 	 *
-	 * @param boolean $throwErrors
+	 * @param bool $throwErrors
 	 */
 	public function __construct( $throwErrors = false ) {
 		$this->throwErrors = $throwErrors;

--- a/tests/phpunit/DiffTestCase.php
+++ b/tests/phpunit/DiffTestCase.php
@@ -39,8 +39,8 @@ abstract class DiffTestCase extends \PHPUnit_Framework_TestCase {
 	 *
 	 * @param array $expected
 	 * @param array $actual
-	 * @param boolean $ordered If the order of the values should match
-	 * @param boolean $named If the keys should match
+	 * @param bool $ordered If the order of the values should match
+	 * @param bool $named If the keys should match
 	 */
 	protected function assertArrayEquals( array $expected, array $actual, $ordered = false, $named = false ) {
 		if ( !$ordered ) {


### PR DESCRIPTION
Reasoning: `boolean` is an alias. `is_boolean` doesn't even exist in PHP.