### PR TITLE
More specific array type hints/docs

### DIFF
--- a/src/DiffOp/Diff/Diff.php
+++ b/src/DiffOp/Diff/Diff.php
@@ -28,7 +28,7 @@ class Diff extends \ArrayObject implements DiffOp {
 	/**
 	 * Pointers to the operations of certain types for quick lookup.
 	 *
-	 * @var array
+	 * @var array[]
 	 */
 	private $typePointers = array(
 		'add' => array(),

--- a/tests/phpunit/DiffOp/Diff/DiffAsOpTest.php
+++ b/tests/phpunit/DiffOp/Diff/DiffAsOpTest.php
@@ -33,8 +33,6 @@ class DiffAsOpTest extends DiffOpTest {
 	 * @see DiffOpTest::constructorProvider
 	 *
 	 * @since 0.5
-	 *
-	 * @return array
 	 */
 	public function constructorProvider() {
 		$argLists = array(

--- a/tests/phpunit/DiffOp/Diff/DiffTest.php
+++ b/tests/phpunit/DiffOp/Diff/DiffTest.php
@@ -52,6 +52,7 @@ class DiffTest extends DiffTestCase {
 
 	/**
 	 * @dataProvider elementInstancesProvider
+	 * @param DiffOp[] $operations
 	 */
 	public function testGetAdditions( array $operations ) {
 		$diff = new Diff( $operations, true );
@@ -72,6 +73,7 @@ class DiffTest extends DiffTestCase {
 
 	/**
 	 * @dataProvider elementInstancesProvider
+	 * @param DiffOp[] $operations
 	 */
 	public function testGetRemovals( array $operations ) {
 		$diff = new Diff( $operations, true );
@@ -104,6 +106,7 @@ class DiffTest extends DiffTestCase {
 
 	/**
 	 * @dataProvider elementInstancesProvider
+	 * @param DiffOp[] $operations
 	 */
 	public function testAddOperations( array $operations ) {
 		$diff = new Diff();
@@ -115,6 +118,7 @@ class DiffTest extends DiffTestCase {
 
 	/**
 	 * @dataProvider elementInstancesProvider
+	 * @param DiffOp[] $operations
 	 */
 	public function testStuff( array $operations ) {
 		$diff = new Diff( $operations );
@@ -382,7 +386,7 @@ class DiffTest extends DiffTestCase {
 	 *
 	 * @since 0.6
 	 *
-	 * @param array $elements
+	 * @param DiffOp[] $elements
 	 */
 	public function testConstructor( array $elements ) {
 		$arrayObject = new Diff( $elements );
@@ -395,7 +399,7 @@ class DiffTest extends DiffTestCase {
 	 *
 	 * @since 0.6
 	 *
-	 * @param array $elements
+	 * @param DiffOp[] $elements
 	 */
 	public function testIsEmpty( array $elements ) {
 		$arrayObject = new Diff( $elements );
@@ -433,7 +437,7 @@ class DiffTest extends DiffTestCase {
 	 *
 	 * @since 0.6
 	 *
-	 * @param array $elements
+	 * @param DiffOp[] $elements
 	 */
 	public function testAppend( array $elements ) {
 		$list = new Diff();
@@ -534,7 +538,7 @@ class DiffTest extends DiffTestCase {
 	 *
 	 * @since 0.6
 	 *
-	 * @param array $elements
+	 * @param DiffOp[] $elements
 	 */
 	public function testOffsetSet( array $elements ) {
 		if ( $elements === array() ) {

--- a/tests/phpunit/DiffOp/DiffOpAddTest.php
+++ b/tests/phpunit/DiffOp/DiffOpAddTest.php
@@ -31,8 +31,6 @@ class DiffOpAddTest extends DiffOpTest {
 	 * @see DiffOpTest::constructorProvider
 	 *
 	 * @since 0.1
-	 *
-	 * @return array
 	 */
 	public function constructorProvider() {
 		return array(

--- a/tests/phpunit/DiffOp/DiffOpChangeTest.php
+++ b/tests/phpunit/DiffOp/DiffOpChangeTest.php
@@ -32,8 +32,6 @@ class DiffOpChangeTest extends DiffOpTest {
 	 * @see DiffOpTest::constructorProvider
 	 *
 	 * @since 0.1
-	 *
-	 * @return array
 	 */
 	public function constructorProvider() {
 		return array(

--- a/tests/phpunit/DiffOp/DiffOpRemoveTest.php
+++ b/tests/phpunit/DiffOp/DiffOpRemoveTest.php
@@ -32,8 +32,6 @@ class DiffOpRemoveTest extends DiffOpTest {
 	 * @see DiffOpTest::constructorProvider
 	 *
 	 * @since 0.1
-	 *
-	 * @return array
 	 */
 	public function constructorProvider() {
 		return array(

--- a/tests/phpunit/DiffOp/DiffOpTest.php
+++ b/tests/phpunit/DiffOp/DiffOpTest.php
@@ -33,8 +33,6 @@ abstract class DiffOpTest extends DiffTestCase {
 	 * or a string indicating the type of exception that should be thrown (ie not valid either).
 	 *
 	 * @since 0.1
-	 *
-	 * @return array
 	 */
 	public abstract function constructorProvider();
 
@@ -53,7 +51,8 @@ abstract class DiffOpTest extends DiffTestCase {
 	/**
 	 * @since 0.1
 	 *
-	 * @return array [instance, constructor args]
+	 * @return array[] An array of arrays, each containing an instance and an array of constructor
+	 * arguments used to construct the instance.
 	 */
 	public function instanceProvider() {
 		$phpFails = array( $this, 'newInstance' );

--- a/tests/phpunit/DiffTestCase.php
+++ b/tests/phpunit/DiffTestCase.php
@@ -19,7 +19,7 @@ abstract class DiffTestCase extends \PHPUnit_Framework_TestCase {
 	 *
 	 * @param array $elements
 	 *
-	 * @return array
+	 * @return array[]
 	 */
 	protected function arrayWrap( array $elements ) {
 		return array_map(

--- a/tests/phpunit/Patcher/MapPatcherTest.php
+++ b/tests/phpunit/Patcher/MapPatcherTest.php
@@ -81,7 +81,7 @@ class MapPatcherTest extends DiffTestCase {
 				'badges' => array( 'FA' )
 			)
 		);
-		$diff = new Diff( array (
+		$diff = new Diff( array(
 			'nlwiki' => new Diff( array(
 				'name'   => new DiffOpAdd( 'Nyan Cat' ),
 				'badges' => new Diff( array(


### PR DESCRIPTION
I tried to make some of the pretty generic "array" type hints more specific.

Data providers always `@return array[]`, this is not worth documentation.