### PR TITLE
Remove redundant since tags

### DIFF
--- a/src/ArrayComparer/ArrayComparer.php
+++ b/src/ArrayComparer/ArrayComparer.php
@@ -18,8 +18,6 @@ interface ArrayComparer {
 	 *
 	 * Implementations are allowed to hold quantity into account or to disregard it.
 	 *
-	 * @since 0.8
-	 *
 	 * @param array $firstArray
 	 * @param array $secondArray
 	 *

--- a/src/ArrayComparer/NativeArrayComparer.php
+++ b/src/ArrayComparer/NativeArrayComparer.php
@@ -17,8 +17,6 @@ class NativeArrayComparer implements ArrayComparer {
 	 *
 	 * Uses @see array_diff.
 	 *
-	 * @since 0.8
-	 *
 	 * @param array $arrayOne
 	 * @param array $arrayTwo
 	 *

--- a/src/ArrayComparer/OrderedArrayComparer.php
+++ b/src/ArrayComparer/OrderedArrayComparer.php
@@ -29,8 +29,6 @@ class OrderedArrayComparer implements ArrayComparer {
 	/**
 	 * @see ArrayComparer::diffArrays
 	 *
-	 * @since 0.9
-	 *
 	 * @param array $arrayOne
 	 * @param array $arrayTwo
 	 *

--- a/src/ArrayComparer/StrategicArrayComparer.php
+++ b/src/ArrayComparer/StrategicArrayComparer.php
@@ -27,8 +27,6 @@ class StrategicArrayComparer implements ArrayComparer {
 	/**
 	 * @see ArrayComparer::diffArrays
 	 *
-	 * @since 0.8
-	 *
 	 * @param array $arrayOne
 	 * @param array $arrayTwo
 	 *

--- a/src/ArrayComparer/StrictArrayComparer.php
+++ b/src/ArrayComparer/StrictArrayComparer.php
@@ -23,8 +23,6 @@ class StrictArrayComparer implements ArrayComparer {
 	/**
 	 * @see ArrayComparer::diffArrays
 	 *
-	 * @since 0.8
-	 *
 	 * @param array $arrayOne
 	 * @param array $arrayTwo
 	 *

--- a/src/Comparer/CallbackComparer.php
+++ b/src/Comparer/CallbackComparer.php
@@ -16,8 +16,6 @@ class CallbackComparer implements ValueComparer {
 	private $callback;
 
 	/**
-	 * @since 0.6
-	 *
 	 * @param callable $callback
 	 */
 	public function __construct( $callback ) {

--- a/src/Comparer/ValueComparer.php
+++ b/src/Comparer/ValueComparer.php
@@ -13,8 +13,6 @@ namespace Diff\Comparer;
 interface ValueComparer {
 
 	/**
-	 * @since 0.6
-	 *
 	 * @param mixed $firstValue
 	 * @param mixed $secondValue
 	 *

--- a/src/DiffOp/AtomicDiffOp.php
+++ b/src/DiffOp/AtomicDiffOp.php
@@ -17,8 +17,6 @@ abstract class AtomicDiffOp implements DiffOp {
 	/**
 	 * @see Countable::count
 	 *
-	 * @since 0.1
-	 *
 	 * @return int
 	 */
 	public function count() {
@@ -27,8 +25,6 @@ abstract class AtomicDiffOp implements DiffOp {
 
 	/**
 	 * @see DiffOp::isAtomic
-	 *
-	 * @since 0.1
 	 *
 	 * @return bool
 	 */

--- a/src/DiffOp/Diff/Diff.php
+++ b/src/DiffOp/Diff/Diff.php
@@ -47,8 +47,6 @@ class Diff extends ArrayObject implements DiffOp {
 	private $indexOffset = 0;
 
 	/**
-	 * @since 0.1
-	 *
 	 * @param DiffOp[] $operations
 	 * @param bool|null $isAssociative
 	 *
@@ -75,8 +73,6 @@ class Diff extends ArrayObject implements DiffOp {
 	/**
 	 * @see Diff::getOperations
 	 *
-	 * @since 0.1
-	 *
 	 * @return DiffOp[]
 	 */
 	public function getOperations() {
@@ -84,8 +80,6 @@ class Diff extends ArrayObject implements DiffOp {
 	}
 
 	/**
-	 * @since 0.1
-	 *
 	 * @param string $type
 	 *
 	 * @return DiffOp[]
@@ -99,8 +93,6 @@ class Diff extends ArrayObject implements DiffOp {
 
 	/**
 	 * @see Diff::addOperations
-	 *
-	 * @since 0.1
 	 *
 	 * @param DiffOp[] $operations
 	 */
@@ -143,8 +135,6 @@ class Diff extends ArrayObject implements DiffOp {
 	/**
 	 * @see Serializable::unserialize
 	 *
-	 * @since 0.1
-	 *
 	 * @param string $serialization
 	 */
 	public function unserialize( $serialization ) {
@@ -172,8 +162,6 @@ class Diff extends ArrayObject implements DiffOp {
 	}
 
 	/**
-	 * @since 0.1
-	 *
 	 * @return DiffOpAdd[]
 	 */
 	public function getAdditions() {
@@ -181,8 +169,6 @@ class Diff extends ArrayObject implements DiffOp {
 	}
 
 	/**
-	 * @since 0.1
-	 *
 	 * @return DiffOpRemove[]
 	 */
 	public function getRemovals() {
@@ -190,8 +176,6 @@ class Diff extends ArrayObject implements DiffOp {
 	}
 
 	/**
-	 * @since 0.1
-	 *
 	 * @return DiffOpChange[]
 	 */
 	public function getChanges() {
@@ -200,8 +184,6 @@ class Diff extends ArrayObject implements DiffOp {
 
 	/**
 	 * Returns the added values.
-	 *
-	 * @since 0.1
 	 *
 	 * @return array of mixed
 	 */
@@ -217,8 +199,6 @@ class Diff extends ArrayObject implements DiffOp {
 	/**
 	 * Returns the removed values.
 	 *
-	 * @since 0.1
-	 *
 	 * @return array of mixed
 	 */
 	public function getRemovedValues() {
@@ -233,8 +213,6 @@ class Diff extends ArrayObject implements DiffOp {
 	/**
 	 * @see DiffOp::isAtomic
 	 *
-	 * @since 0.1
-	 *
 	 * @return bool
 	 */
 	public function isAtomic() {
@@ -243,8 +221,6 @@ class Diff extends ArrayObject implements DiffOp {
 
 	/**
 	 * @see DiffOp::getType
-	 *
-	 * @since 0.1
 	 *
 	 * @return string
 	 */
@@ -259,8 +235,6 @@ class Diff extends ArrayObject implements DiffOp {
 	 * holds two atomic operations will be 3.
 	 *
 	 * @see Countable::count
-	 *
-	 * @since 0.1
 	 *
 	 * @return int
 	 */
@@ -393,8 +367,6 @@ class Diff extends ArrayObject implements DiffOp {
 	/**
 	 * @see ArrayObject::append
 	 *
-	 * @since 0.1
-	 *
 	 * @param mixed $value
 	 */
 	public function append( $value ) {
@@ -403,8 +375,6 @@ class Diff extends ArrayObject implements DiffOp {
 
 	/**
 	 * @see ArrayObject::offsetSet()
-	 *
-	 * @since 0.1
 	 *
 	 * @param int|string $index
 	 * @param mixed $value
@@ -446,8 +416,6 @@ class Diff extends ArrayObject implements DiffOp {
 	/**
 	 * @see Serializable::serialize
 	 *
-	 * @since 0.1
-	 *
 	 * @return string
 	 */
 	public function serialize() {
@@ -465,8 +433,6 @@ class Diff extends ArrayObject implements DiffOp {
 
 	/**
 	 * Returns if the ArrayObject has no elements.
-	 *
-	 * @since 0.1
 	 *
 	 * @return bool
 	 */

--- a/src/DiffOp/Diff/ListDiff.php
+++ b/src/DiffOp/Diff/ListDiff.php
@@ -24,8 +24,6 @@ class ListDiff extends Diff {
 	/**
 	 * @see DiffOp::getType
 	 *
-	 * @since 0.1
-	 *
 	 * @return string
 	 */
 	public function getType() {

--- a/src/DiffOp/Diff/MapDiff.php
+++ b/src/DiffOp/Diff/MapDiff.php
@@ -25,8 +25,6 @@ class MapDiff extends Diff {
 	/**
 	 * @see DiffOp::getType
 	 *
-	 * @since 0.1
-	 *
 	 * @return string
 	 */
 	public function getType() {

--- a/src/DiffOp/DiffOp.php
+++ b/src/DiffOp/DiffOp.php
@@ -18,8 +18,6 @@ interface DiffOp extends \Serializable, \Countable {
 	/**
 	 * Returns a string identifier for the operation type.
 	 *
-	 * @since 0.1
-	 *
 	 * @return string
 	 */
 	public function getType();
@@ -27,8 +25,6 @@ interface DiffOp extends \Serializable, \Countable {
 	/**
 	 * Returns if the operation is atomic, opposing to it
 	 * being a composite that can contain one or more child elements.
-	 *
-	 * @since 0.1
 	 *
 	 * @return bool
 	 */

--- a/src/DiffOp/DiffOpAdd.php
+++ b/src/DiffOp/DiffOpAdd.php
@@ -18,8 +18,6 @@ class DiffOpAdd extends AtomicDiffOp {
 	/**
 	 * @see DiffOp::getType
 	 *
-	 * @since 0.1
-	 *
 	 * @return string
 	 */
 	public function getType() {
@@ -27,8 +25,6 @@ class DiffOpAdd extends AtomicDiffOp {
 	}
 
 	/**
-	 * @since 0.1
-	 *
 	 * @param mixed $newValue
 	 */
 	public function __construct( $newValue ) {
@@ -36,8 +32,6 @@ class DiffOpAdd extends AtomicDiffOp {
 	}
 
 	/**
-	 * @since 0.1
-	 *
 	 * @return mixed
 	 */
 	public function getNewValue() {
@@ -47,8 +41,6 @@ class DiffOpAdd extends AtomicDiffOp {
 	/**
 	 * @see Serializable::serialize
 	 *
-	 * @since 0.1
-	 *
 	 * @return string|null
 	 */
 	public function serialize() {
@@ -57,8 +49,6 @@ class DiffOpAdd extends AtomicDiffOp {
 
 	/**
 	 * @see Serializable::unserialize
-	 *
-	 * @since 0.1
 	 *
 	 * @param string $serialization
 	 *

--- a/src/DiffOp/DiffOpChange.php
+++ b/src/DiffOp/DiffOpChange.php
@@ -19,8 +19,6 @@ class DiffOpChange extends AtomicDiffOp {
 	/**
 	 * @see DiffOp::getType
 	 *
-	 * @since 0.1
-	 *
 	 * @return string
 	 */
 	public function getType() {
@@ -28,8 +26,6 @@ class DiffOpChange extends AtomicDiffOp {
 	}
 
 	/**
-	 * @since 0.1
-	 *
 	 * @param mixed $oldValue
 	 * @param mixed $newValue
 	 */
@@ -39,8 +35,6 @@ class DiffOpChange extends AtomicDiffOp {
 	}
 
 	/**
-	 * @since 0.1
-	 *
 	 * @return mixed
 	 */
 	public function getOldValue() {
@@ -48,8 +42,6 @@ class DiffOpChange extends AtomicDiffOp {
 	}
 
 	/**
-	 * @since 0.1
-	 *
 	 * @return mixed
 	 */
 	public function getNewValue() {
@@ -59,8 +51,6 @@ class DiffOpChange extends AtomicDiffOp {
 	/**
 	 * @see Serializable::serialize
 	 *
-	 * @since 0.1
-	 *
 	 * @return string|null
 	 */
 	public function serialize() {
@@ -69,8 +59,6 @@ class DiffOpChange extends AtomicDiffOp {
 
 	/**
 	 * @see Serializable::unserialize
-	 *
-	 * @since 0.1
 	 *
 	 * @param string $serialization
 	 *

--- a/src/DiffOp/DiffOpRemove.php
+++ b/src/DiffOp/DiffOpRemove.php
@@ -18,8 +18,6 @@ class DiffOpRemove extends AtomicDiffOp {
 	/**
 	 * @see DiffOp::getType
 	 *
-	 * @since 0.1
-	 *
 	 * @return string
 	 */
 	public function getType() {
@@ -27,8 +25,6 @@ class DiffOpRemove extends AtomicDiffOp {
 	}
 
 	/**
-	 * @since 0.1
-	 *
 	 * @param mixed $oldValue
 	 */
 	public function __construct( $oldValue ) {
@@ -36,8 +32,6 @@ class DiffOpRemove extends AtomicDiffOp {
 	}
 
 	/**
-	 * @since 0.1
-	 *
 	 * @return mixed
 	 */
 	public function getOldValue() {
@@ -47,8 +41,6 @@ class DiffOpRemove extends AtomicDiffOp {
 	/**
 	 * @see Serializable::serialize
 	 *
-	 * @since 0.1
-	 *
 	 * @return string|null
 	 */
 	public function serialize() {
@@ -57,8 +49,6 @@ class DiffOpRemove extends AtomicDiffOp {
 
 	/**
 	 * @see Serializable::unserialize
-	 *
-	 * @since 0.1
 	 *
 	 * @param string $serialization
 	 *

--- a/src/DiffOpFactory.php
+++ b/src/DiffOpFactory.php
@@ -19,8 +19,6 @@ class DiffOpFactory {
 	private $valueConverter;
 
 	/**
-	 * @since 0.5
-	 *
 	 * @param callable|null $valueConverter optional callback used to convert special
 	 *        array structures into objects used as values in atomic diff ops.
 	 */
@@ -32,8 +30,6 @@ class DiffOpFactory {
 	 * Returns an instance of DiffOp constructed from the provided array.
 	 *
 	 * This roundtrips with @see DiffOp::toArray.
-	 *
-	 * @since 0.5
 	 *
 	 * @param array $diffOp
 	 *
@@ -78,8 +74,6 @@ class DiffOpFactory {
 	}
 
 	/**
-	 * @since 0.5
-	 *
 	 * @param string $key
 	 * @param array $diffOp
 	 *

--- a/src/Differ/CallbackListDiffer.php
+++ b/src/Differ/CallbackListDiffer.php
@@ -25,8 +25,6 @@ class CallbackListDiffer implements Differ {
 	private $differ;
 
 	/**
-	 * @since 0.5
-	 *
 	 * @param callable $comparisonCallback
 	 */
 	public function __construct( $comparisonCallback ) {
@@ -37,8 +35,6 @@ class CallbackListDiffer implements Differ {
 
 	/**
 	 * @see Differ::doDiff
-	 *
-	 * @since 0.5
 	 *
 	 * @param array $oldValues The first array
 	 * @param array $newValues The second array

--- a/src/Differ/Differ.php
+++ b/src/Differ/Differ.php
@@ -18,8 +18,6 @@ interface Differ {
 	/**
 	 * Takes two arrays, computes the diff, and returns this diff as an array of DiffOp.
 	 *
-	 * @since 0.4
-	 *
 	 * @param array $oldValues The first array
 	 * @param array $newValues The second array
 	 *

--- a/src/Differ/ListDiffer.php
+++ b/src/Differ/ListDiffer.php
@@ -27,7 +27,6 @@ class ListDiffer implements Differ {
 	 * Use non-strict comparison and do not care about quantity.
 	 * This makes use of @see array_diff
 	 *
-	 * @since 0.4
 	 * @deprecated since 0.8, use new NativeArrayComparer() instead
 	 */
 	const MODE_NATIVE = 0;
@@ -36,7 +35,6 @@ class ListDiffer implements Differ {
 	 * Use strict comparison and care about quantity.
 	 * This makes use of @see ListDiffer::strictDiff
 	 *
-	 * @since 0.4
 	 * @deprecated since 0.8, use null instead
 	 */
 	const MODE_STRICT = 1;
@@ -83,8 +81,6 @@ class ListDiffer implements Differ {
 
 	/**
 	 * @see Differ::doDiff
-	 *
-	 * @since 0.4
 	 *
 	 * @param array $oldValues The first array
 	 * @param array $newValues The second array

--- a/src/Differ/MapDiffer.php
+++ b/src/Differ/MapDiffer.php
@@ -37,8 +37,6 @@ class MapDiffer implements Differ {
 	private $comparisonCallback = null;
 
 	/**
-	 * @since 0.4
-	 *
 	 * @param bool $recursively
 	 * @param Differ $listDiffer
 	 */
@@ -68,8 +66,6 @@ class MapDiffer implements Differ {
 	 * @see Differ::doDiff
 	 *
 	 * Computes the diff between two associate arrays.
-	 *
-	 * @since 0.4
 	 *
 	 * @param array $oldValues The first array
 	 * @param array $newValues The second array

--- a/src/Differ/OrderedListDiffer.php
+++ b/src/Differ/OrderedListDiffer.php
@@ -26,8 +26,6 @@ class OrderedListDiffer implements Differ {
 	private $differ;
 
 	/**
-	 * @since 0.9
-	 *
 	 * @param ValueComparer $comparer
 	 */
 	public function __construct( ValueComparer $comparer ) {
@@ -36,8 +34,6 @@ class OrderedListDiffer implements Differ {
 
 	/**
 	 * @see Differ::doDiff
-	 *
-	 * @since 0.9
 	 *
 	 * @param array $oldValues The first array
 	 * @param array $newValues The second array

--- a/src/Patcher/ListPatcher.php
+++ b/src/Patcher/ListPatcher.php
@@ -25,8 +25,6 @@ class ListPatcher extends ThrowingPatcher {
 	 * For instance, when the input is [ 0 => 'a', 1 => 'b', 2 => 'c' ], and there
 	 * is one remove operation for 'b', the result will be [ 0 => 'a', 2 => 'c' ].
 	 *
-	 * @since 0.4
-	 *
 	 * @param array $base
 	 * @param Diff $diff
 	 *

--- a/src/Patcher/MapPatcher.php
+++ b/src/Patcher/MapPatcher.php
@@ -30,8 +30,6 @@ class MapPatcher extends ThrowingPatcher {
 	private $comparer = null;
 
 	/**
-	 * @since 0.4
-	 *
 	 * @param bool $throwErrors
 	 * @param Patcher|null $listPatcher The patcher that will be used for lists in the value
 	 */
@@ -54,8 +52,6 @@ class MapPatcher extends ThrowingPatcher {
 	 * It is possible to pass in non-associative diffs (those for which isAssociative)
 	 * returns false, however the likely intended behavior can be obtained via
 	 * a list patcher.
-	 *
-	 * @since 0.4
 	 *
 	 * @param array $base
 	 * @param Diff $diff

--- a/src/Patcher/Patcher.php
+++ b/src/Patcher/Patcher.php
@@ -18,8 +18,6 @@ interface Patcher {
 	 * Applies the applicable operations from the provided diff to
 	 * the provided base value.
 	 *
-	 * @since 0.4
-	 *
 	 * @param array $base
 	 * @param Diff $diffOps
 	 *

--- a/src/Patcher/PreviewablePatcher.php
+++ b/src/Patcher/PreviewablePatcher.php
@@ -22,8 +22,6 @@ interface PreviewablePatcher extends Patcher {
 	 * The returned operations are thus the difference between
 	 * the result of @see patch and it's input base value.
 	 *
-	 * @since 0.4
-	 *
 	 * @param array $base
 	 * @param Diff $diffOps
 	 *

--- a/src/Patcher/ThrowingPatcher.php
+++ b/src/Patcher/ThrowingPatcher.php
@@ -24,8 +24,6 @@ abstract class ThrowingPatcher implements PreviewablePatcher {
 	private $throwErrors;
 
 	/**
-	 * @since 0.4
-	 *
 	 * @param bool $throwErrors
 	 */
 	public function __construct( $throwErrors = false ) {
@@ -33,8 +31,6 @@ abstract class ThrowingPatcher implements PreviewablePatcher {
 	}
 
 	/**
-	 * @since 0.4
-	 *
 	 * @param string $message
 	 *
 	 * @throws PatcherException
@@ -47,8 +43,6 @@ abstract class ThrowingPatcher implements PreviewablePatcher {
 
 	/**
 	 * Set the patcher to ignore errors.
-	 *
-	 * @since 0.4
 	 */
 	public function ignoreErrors() {
 		$this->throwErrors = false;
@@ -56,8 +50,6 @@ abstract class ThrowingPatcher implements PreviewablePatcher {
 
 	/**
 	 * Set the patcher to throw errors.
-	 *
-	 * @since 0.4
 	 */
 	public function throwErrors() {
 		$this->throwErrors = true;
@@ -65,8 +57,6 @@ abstract class ThrowingPatcher implements PreviewablePatcher {
 
 	/**
 	 * @see PreviewablePatcher::getApplicableDiff
-	 *
-	 * @since 0.4
 	 *
 	 * @param array $base
 	 * @param Diff $diff


### PR DESCRIPTION
These tags on the method level are all identical to the same tag on the class level, therefore being redundant and not adding information that's not already there.