### PR TITLE
Avoid full qualified class names

### DIFF
--- a/src/DiffOp/DiffOp.php
+++ b/src/DiffOp/DiffOp.php
@@ -2,6 +2,9 @@
 
 namespace Diff\DiffOp;
 
+use Countable;
+use Serializable;
+
 /**
  * Interface for diff operations. A diff operation
  * represents a change to a single element.
@@ -13,7 +16,7 @@ namespace Diff\DiffOp;
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-interface DiffOp extends \Serializable, \Countable {
+interface DiffOp extends Serializable, Countable {
 
 	/**
 	 * Returns a string identifier for the operation type.

--- a/src/Patcher/PatcherException.php
+++ b/src/Patcher/PatcherException.php
@@ -2,6 +2,14 @@
 
 namespace Diff\Patcher;
 
-class PatcherException extends \RuntimeException {
+use RuntimeException;
+
+/**
+ * @since 0.4
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class PatcherException extends RuntimeException {
 
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,6 +14,8 @@ if ( !is_readable( __DIR__ . '/../vendor/autoload.php' ) ) {
 	die( 'You need to install this package with Composer before you can run the tests' );
 }
 
-$autoLoader = require __DIR__ . '/../vendor/autoload.php';
+$classLoader = require __DIR__ . '/../vendor/autoload.php';
 
-$autoLoader->addPsr4( 'Diff\\Tests\\', __DIR__ . '/phpunit/' );
+$classLoader->addPsr4( 'Diff\\Tests\\', __DIR__ . '/phpunit/' );
+
+unset( $classLoader );

--- a/tests/phpunit/DiffOp/Diff/MapDiffTest.php
+++ b/tests/phpunit/DiffOp/Diff/MapDiffTest.php
@@ -355,7 +355,7 @@ class MapDiffTest extends DiffOpTest {
 		$diff = new Diff( $differ->doDiff( $old, $new ) );
 
 		$this->assertTrue( $diff->isEmpty() );
-		$this->assertTrue( $diff->getOperations() === array() );
+		$this->assertSame( array(), $diff->getOperations() );
 	}
 
 }


### PR DESCRIPTION
Plus some minor code style issues, mostly for consistency across the Wikibase code base:
* Avoid assertTrue with ===, there is assertSame for that.
* Unset global variable in test bootstrap.
* Add a missing doc block.