### PR TITLE
Exclude PHPCS messages instead of setting severity to 0

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -79,9 +79,8 @@
     <rule ref="Squiz.Functions.GlobalFunction" />
     <rule ref="Squiz.Scope" />
 
-    <rule ref="Squiz.Strings.DoubleQuoteUsage" />
-    <rule ref="Squiz.Strings.DoubleQuoteUsage.ContainsVar">
-        <severity>0</severity>
+    <rule ref="Squiz.Strings.DoubleQuoteUsage">
+        <exclude name="Squiz.Strings.DoubleQuoteUsage.ContainsVar" />
     </rule>
 
     <rule ref="Squiz.WhiteSpace.CastSpacing" />


### PR DESCRIPTION
In this case this is only for style, to have a uniform best practice across all our PHPCS rule sets.

When you exclude a whole sniff (e.g. "Vendor.Namespace.Sniff"), the sniff is not run and the test runs faster. This is not possible here, because this sniff can report two things, and only one should be disabled.