### PR TITLE
Use composer installed PHPUnit in build

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
 	},
 	"require-dev": {
 		"squizlabs/php_codesniffer": "~2.3",
-		"phpmd/phpmd": "~2.3"
+		"phpmd/phpmd": "~2.3",
+		"phpunit/phpunit": "~4.8"
 	},
 	"autoload": {
 		"files" : [
@@ -45,15 +46,15 @@
 	"scripts": {
 		"test": [
 			"composer validate --no-interaction",
-			"phpunit"
+			"vendor/bin/phpunit"
 		],
 		"cs": [
-			"composer phpcs",
-			"composer phpmd"
+			"@phpcs",
+			"@phpmd"
 		],
 		"ci": [
-			"composer test",
-			"composer cs"
+			"@test",
+			"@cs"
 		],
 		"phpcs": [
 			"vendor/bin/phpcs src/* tests/* --standard=phpcs.xml --extensions=php -sp"


### PR DESCRIPTION
This is to avoid getting a crapton of warnings when using recent PHPUnit
versions. Fun fact: we cannot avoid those warnings without becomming
unsable to run the build on PHPUnit older than 5.6 due to recent PHPUnit
requiring 5.6 or later, and it deprecating things for which the alternative
was introduced in those same versions. #MAW