### PR TITLE
rename MapDiffer Method

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ $newVersion = array(
 );
 
 $differ = new MapDiffer();
-$diff = $differ->diff( $oldVersion, $newVersion );
+$diff = $differ->doDiff( $oldVersion, $newVersion );
 ```
 
 ### Applying a diff as patch


### PR DESCRIPTION
MapDiffer()->diff() method was undefined, changed to doDiff()