### PR TITLE
Upperbound ockcyp/covers-validator version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 	"require-dev": {
 		"phpunit/phpunit": "~6.0",
 		"squizlabs/php_codesniffer": "~2.3",
-		"ockcyp/covers-validator": "~0.4"
+		"ockcyp/covers-validator": "~0.6.1"
 	},
 	"autoload": {
 		"files" : [


### PR DESCRIPTION
Effective lowerbound increased from 0.6.0 to 0.6.1