### PR TITLE
Optimize Diff::isEmpty for performance

### DIFF
--- a/src/DiffOp/Diff/Diff.php
+++ b/src/DiffOp/Diff/Diff.php
@@ -450,14 +450,19 @@ class Diff extends ArrayObject implements DiffOp {
 	}
 
 	/**
-	 * Returns if the ArrayObject has no elements.
-	 *
 	 * @since 0.1
 	 *
 	 * @return bool
 	 */
 	public function isEmpty(): bool {
-		return $this->count() === 0;
+		/** @var DiffOp $diffOp */
+		foreach ( $this as $diffOp ) {
+			if ( $diffOp->count() > 0 ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 }


### PR DESCRIPTION
Instead of always iterating the entire tree, stop immediately when at least one atomic diff operation was found.

I'm also removing the methods description, which is actually not true.