### PR TITLE
ListPatcher: use non-strict comparison when removing objects

### DIFF
--- a/src/Patcher/ListPatcher.php
+++ b/src/Patcher/ListPatcher.php
@@ -44,7 +44,8 @@ class ListPatcher extends ThrowingPatcher {
 			if ( $diffOp instanceof DiffOpAdd ) {
 				$base[] = $diffOp->getNewValue();
 			} elseif ( $diffOp instanceof DiffOpRemove ) {
-				$key = array_search( $diffOp->getOldValue(), $base, true );
+				$needle = $diffOp->getOldValue();
+				$key = array_search( $needle, $base, !is_object( $needle ) );
 
 				if ( $key === false ) {
 					$this->handleError( 'Cannot remove an element from a list if it is not present' );

--- a/tests/phpunit/Patcher/ListPatcherTest.php
+++ b/tests/phpunit/Patcher/ListPatcherTest.php
@@ -10,6 +10,7 @@ use Diff\DiffOp\DiffOpRemove;
 use Diff\Patcher\ListPatcher;
 use Diff\Patcher\Patcher;
 use Diff\Tests\DiffTestCase;
+use stdClass;
 
 /**
  * @covers Diff\Patcher\ListPatcher
@@ -91,7 +92,26 @@ class ListPatcherTest extends DiffTestCase {
 
 		$argLists[] = array( $patcher, $base, $diff, $expected );
 
+		$patcher = new ListPatcher();
+		$base = array(
+			$this->newObject( 'foo' ),
+			$this->newObject( 'bar' ),
+		);
+		$diff = new Diff( array(
+			new DiffOpRemove( $this->newObject( 'foo') ),
+			new DiffOpAdd( $this->newObject( 'baz' ) ),
+		) );
+		$expected = array( $this->newObject( 'bar' ), $this->newObject( 'baz' ) );
+
+		$argLists[] = array( $patcher, $base, $diff, $expected );
+
 		return $argLists;
+	}
+
+	private function newObject( $value ) : stdClass {
+		$object = new stdClass();
+		$object->element = $value;
+		return $object;
 	}
 
 	/**


### PR DESCRIPTION
Background: discovered in Wikibase when trying to apply a patch removing an ItemId object from the list of ItemId objects. This failed if the "same" ID was in the list, but it was not technically the same object in memory.

While discussing the issue with @wiese and @jakobw, we've mentioned that further extension would be to allow to provide a function/object that would allow custom object comparison if something more sophisticated than PHP's native object non-strict comparison (i.e. all attribute and their values comparison) is needed. Not implemented here as there does not seem to be a use for such extension yet.