### PR TITLE
ListPatcher object comparison fix - backport to 2.x branch and release 2.3.0

### DIFF
--- a/Diff.php
+++ b/Diff.php
@@ -5,7 +5,7 @@ if ( defined( 'Diff_VERSION' ) ) {
 	return 1;
 }
 
-define( 'Diff_VERSION', '2.2' );
+define( 'Diff_VERSION', '2.3' );
 
 // Aliasing of classes that got renamed.
 // For more details, see Aliases.php.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,6 +3,10 @@ These are the release notes for the [Diff library](README.md).
 Latest release:
 [![Latest Stable Version](https://poser.pugx.org/diff/diff/version.png)](https://packagist.org/packages/diff/diff)
 
+## Version 2.3 (2018-04-11)
+
+* Fixed bug in `ListPatcher` that caused it to compare objects by identity rather than by value
+
 ## Version 2.2 (2017-08-09)
 
 * Removed MediaWiki extension registration

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "2.2.x-dev"
+			"dev-master": "2.3.x-dev"
 		}
 	},
 	"scripts": {

--- a/src/Patcher/ListPatcher.php
+++ b/src/Patcher/ListPatcher.php
@@ -42,7 +42,8 @@ class ListPatcher extends ThrowingPatcher {
 			if ( $diffOp instanceof DiffOpAdd ) {
 				$base[] = $diffOp->getNewValue();
 			} elseif ( $diffOp instanceof DiffOpRemove ) {
-				$key = array_search( $diffOp->getOldValue(), $base, true );
+				$needle = $diffOp->getOldValue();
+				$key = array_search( $needle, $base, !is_object( $needle ) );
 
 				if ( $key === false ) {
 					$this->handleError( 'Cannot remove an element from a list if it is not present' );

--- a/tests/phpunit/Patcher/ListPatcherTest.php
+++ b/tests/phpunit/Patcher/ListPatcherTest.php
@@ -8,6 +8,7 @@ use Diff\DiffOp\DiffOpRemove;
 use Diff\Patcher\ListPatcher;
 use Diff\Patcher\Patcher;
 use Diff\Tests\DiffTestCase;
+use stdClass;
 
 /**
  * @covers Diff\Patcher\ListPatcher
@@ -89,7 +90,26 @@ class ListPatcherTest extends DiffTestCase {
 
 		$argLists[] = array( $patcher, $base, $diff, $expected );
 
+		$patcher = new ListPatcher();
+		$base = array(
+			$this->newObject( 'foo' ),
+			$this->newObject( 'bar' ),
+		);
+		$diff = new Diff( array(
+			new DiffOpRemove( $this->newObject( 'foo' ) ),
+			new DiffOpAdd( $this->newObject( 'baz' ) ),
+		) );
+		$expected = array( $this->newObject( 'bar' ), $this->newObject( 'baz' ) );
+
+		$argLists[] = array( $patcher, $base, $diff, $expected );
+
 		return $argLists;
+	}
+
+	private function newObject( $value ) {
+		$object = new stdClass();
+		$object->element = $value;
+		return $object;
 	}
 
 	/**


### PR DESCRIPTION
This is backporting https://github.com/wmde/Diff/pull/92 onto PHP 5-compatible branch and makes a new release for the use in Wikibase.