### PR TITLE
Optimize Diff::isEmpty for performance

### DIFF
--- a/src/DiffOp/Diff/Diff.php
+++ b/src/DiffOp/Diff/Diff.php
@@ -18,7 +18,7 @@ use InvalidArgumentException;
  * @license GPL-2.0+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Daniel Kinzler
- * @author Thiemo Mättig
+ * @author Thiemo Kreuz
  */
 class Diff extends ArrayObject implements DiffOp {
 
@@ -458,14 +458,19 @@ class Diff extends ArrayObject implements DiffOp {
 	}
 
 	/**
-	 * Returns if the ArrayObject has no elements.
-	 *
 	 * @since 0.1
 	 *
 	 * @return bool
 	 */
 	public function isEmpty() {
-		return $this->count() === 0;
+		/** @var DiffOp $diffOp */
+		foreach ( $this as $diffOp ) {
+			if ( $diffOp->count() > 0 ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 }

--- a/tests/phpunit/DiffOp/Diff/DiffTest.php
+++ b/tests/phpunit/DiffOp/Diff/DiffTest.php
@@ -21,7 +21,7 @@ use stdClass;
  *
  * @license GPL-2.0+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
- * @author Thiemo Mättig
+ * @author Thiemo Kreuz
  */
 class DiffTest extends DiffTestCase {
 


### PR DESCRIPTION
This packports https://github.com/wmde/Diff/pull/89 as well as 52b315ff8df1ab4eb88316de950baa5c760b7bce to the 2.x branch.

Instead of always iterating the entire tree, stop immediately when at least one atomic diff operation was found.

I'm also removing the methods description, which is actually not true.