### PR TITLE
Remove not needed entries from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-*~
-*.kate-swp
-*.swp
-
 .idea/
 build/
 vendor/


### PR DESCRIPTION
Removes the last code by reedy, allowing for his removal from https://github.com/wmde/Diff/issues/106