### PR TITLE
Improve PHPUnit assertion

### DIFF
--- a/tests/unit/DiffOp/Diff/DiffTest.php
+++ b/tests/unit/DiffOp/Diff/DiffTest.php
@@ -258,7 +258,7 @@ class DiffTest extends DiffTestCase {
 	public function testConstructor( array $elements ) {
 		$arrayObject = new Diff( $elements );
 
-		$this->assertEquals( count( $elements ), $arrayObject->count() );
+		$this->assertCount( $arrayObject->count(), $elements );
 	}
 
 	/**


### PR DESCRIPTION
# Changed log

- Using the `assertCount` to assert expected is same as result count.