### PR TITLE
Add support for php 8.1 and drop 7.2 and 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: bionic
 php:
   - 7.4
   - 8.0
-  - 8.1.3
+  - 8.1.0
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: php
 
 php:
-  - 7.2
-  - 7.3
   - 7.4
   - 8.0
+  - 8.1
 
 sudo: false
 
@@ -13,7 +12,7 @@ install: travis_retry composer install --prefer-source
 script: composer ci
 
 after_success:
-  - if [[ "`phpenv version-name`" != "8.0" ]]; then exit 0; fi
+  - if [[ "`phpenv version-name`" != "8.1" ]]; then exit 0; fi
   - vendor/bin/phpunit --coverage-clover coverage.clover
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-
+dist: bionic
 php:
   - 7.4
   - 8.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: bionic
 php:
   - 7.4
   - 8.0
-  - 8.1
+  - 8.1.3
 
 sudo: false
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ A full history of the different versions of Diff can be found in the [release no
 
 ## Requirements
 
+**Diff 4.x:**
+
+* PHP 7.4 or later
+
 **Diff 3.x:**
 
 * PHP 7.0 or later (tested with PHP 7.0 up to PHP 7.4)

--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,12 @@
 		"irc": "irc://irc.freenode.net/wikimedia-de-tech"
 	},
 	"require": {
-		"php": ">=7.2"
+		"php": ">=7.4"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "~8.5.0",
-		"squizlabs/php_codesniffer": "~3.6.0",
-		"ockcyp/covers-validator": "~1.0"
+		"phpunit/phpunit": "^9.5.17",
+		"squizlabs/php_codesniffer": "^3.6.2",
+		"ockcyp/covers-validator": "^1.4"
 	},
 	"autoload": {
 		"files" : [

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,24 +1,13 @@
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="tests/bootstrap.php"
-         cacheTokens="false"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         stopOnError="false"
-         stopOnFailure="false"
-         stopOnIncomplete="false"
-         stopOnSkipped="false"
-         verbose="true">
-    <testsuites>
-        <testsuite name="Diff">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="tests/bootstrap.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" stopOnError="false" stopOnFailure="false" stopOnIncomplete="false" stopOnSkipped="false" verbose="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage includeUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Diff">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/ArrayComparer/StrategicArrayComparer.php
+++ b/src/ArrayComparer/StrategicArrayComparer.php
@@ -19,7 +19,7 @@ use Diff\Comparer\ValueComparer;
  */
 class StrategicArrayComparer implements ArrayComparer {
 
-	private $valueComparer;
+	private ValueComparer $valueComparer;
 
 	public function __construct( ValueComparer $valueComparer ) {
 		$this->valueComparer = $valueComparer;

--- a/src/DiffOp/AtomicDiffOp.php
+++ b/src/DiffOp/AtomicDiffOp.php
@@ -51,7 +51,7 @@ abstract class AtomicDiffOp implements DiffOp {
 	 *
 	 * @return mixed The $value unchanged, or the return value of calling $valueConverter on $value.
 	 */
-	protected function objectToArray( $value, $valueConverter = null ) {
+	protected function objectToArray( $value, ?callable $valueConverter = null ) {
 		if ( $valueConverter !== null && is_object( $value ) ) {
 			$value = call_user_func( $valueConverter, $value );
 		}

--- a/src/DiffOp/Diff/Diff.php
+++ b/src/DiffOp/Diff/Diff.php
@@ -145,21 +145,27 @@ class Diff extends ArrayObject implements DiffOp {
 	 *
 	 * @param string $serialization
 	 */
-	public function unserialize( $serialization ) {
-		$serializationData = unserialize( $serialization );
+	public function unserialize( $serialization ): void {
+		$this->__unserialize( $serialization );
+	}
 
-		foreach ( $serializationData['data'] as $offset => $value ) {
+	/**
+	 * @param string $serialization
+	 */
+	public function __unserialize( $serialization ): void {
+		/** @var array $serialization */
+		foreach ( $serialization['data'] as $offset => $value ) {
 			// Just set the element, bypassing checks and offset resolving,
 			// as these elements have already gone through this.
 			parent::offsetSet( $offset, $value );
 		}
 
-		$this->indexOffset = $serializationData['index'];
+		$this->indexOffset = $serialization['index'];
 
-		$this->typePointers = $serializationData['typePointers'];
+		$this->typePointers = $serialization['typePointers'];
 
-		if ( array_key_exists( 'assoc', $serializationData ) ) {
-			$this->isAssociative = $serializationData['assoc'] === 'n' ? null : $serializationData['assoc'] === 't';
+		if ( array_key_exists( 'assoc', $serialization ) ) {
+			$this->isAssociative = $serialization['assoc'] === 'n' ? null : $serialization['assoc'] === 't';
 		}
 	}
 
@@ -337,7 +343,7 @@ class Diff extends ArrayObject implements DiffOp {
 		return [
 			'type' => $this->getType(),
 			'isassoc' => $this->isAssociative,
-			'operations' => $operations
+			'operations' => $operations,
 		];
 	}
 
@@ -383,7 +389,7 @@ class Diff extends ArrayObject implements DiffOp {
 	 *
 	 * @param mixed $value
 	 */
-	public function append( $value ) {
+	public function append( $value ): void {
 		$this->setElement( null, $value );
 	}
 
@@ -395,7 +401,7 @@ class Diff extends ArrayObject implements DiffOp {
 	 * @param int|string $index
 	 * @param mixed $value
 	 */
-	public function offsetSet( $index, $value ) {
+	public function offsetSet( $index, $value ): void {
 		$this->setElement( $index, $value );
 	}
 
@@ -436,17 +442,22 @@ class Diff extends ArrayObject implements DiffOp {
 	 *
 	 * @return string
 	 */
-	public function serialize() {
+	public function serialize(): string {
+		return serialize( $this->__serialize() );
+	}
+
+	/**
+	 * @return array
+	 */
+	public function __serialize(): array {
 		$assoc = $this->isAssociative === null ? 'n' : ( $this->isAssociative ? 't' : 'f' );
 
-		$data = [
+		return [
 			'data' => $this->getArrayCopy(),
 			'index' => $this->indexOffset,
 			'typePointers' => $this->typePointers,
-			'assoc' => $assoc
+			'assoc' => $assoc,
 		];
-
-		return serialize( $data );
 	}
 
 	/**

--- a/src/DiffOp/Diff/Diff.php
+++ b/src/DiffOp/Diff/Diff.php
@@ -24,17 +24,12 @@ use InvalidArgumentException;
  */
 class Diff extends ArrayObject implements DiffOp {
 
-	/**
-	 * @var bool|null
-	 */
-	private $isAssociative = null;
+	private ?bool $isAssociative = null;
 
 	/**
 	 * Pointers to the operations of certain types for quick lookup.
-	 *
-	 * @var array[]
 	 */
-	private $typePointers = [
+	private array $typePointers = [
 		'add' => [],
 		'remove' => [],
 		'change' => [],
@@ -43,10 +38,7 @@ class Diff extends ArrayObject implements DiffOp {
 		'diff' => [],
 	];
 
-	/**
-	 * @var int
-	 */
-	private $indexOffset = 0;
+	private int $indexOffset = 0;
 
 	/**
 	 * @since 0.1
@@ -138,28 +130,19 @@ class Diff extends ArrayObject implements DiffOp {
 		return true;
 	}
 
-	/**
-	 * @see Serializable::unserialize
-	 *
-	 * @since 0.1
-	 *
-	 * @param string $serialization
-	 */
-	public function unserialize( $serialization ) {
-		$serializationData = unserialize( $serialization );
-
-		foreach ( $serializationData['data'] as $offset => $value ) {
+	public function __unserialize( array $data ): void {
+		foreach ( $data['data'] as $offset => $value ) {
 			// Just set the element, bypassing checks and offset resolving,
 			// as these elements have already gone through this.
 			parent::offsetSet( $offset, $value );
 		}
 
-		$this->indexOffset = $serializationData['index'];
+		$this->indexOffset = $data['index'];
 
-		$this->typePointers = $serializationData['typePointers'];
+		$this->typePointers = $data['typePointers'];
 
-		if ( array_key_exists( 'assoc', $serializationData ) ) {
-			$this->isAssociative = $serializationData['assoc'] === 'n' ? null : $serializationData['assoc'] === 't';
+		if ( array_key_exists( 'assoc', $data ) ) {
+			$this->isAssociative = $data['assoc'] === 'n' ? null : $data['assoc'] === 't';
 		}
 	}
 
@@ -283,7 +266,7 @@ class Diff extends ArrayObject implements DiffOp {
 	 *
 	 * @return bool|null
 	 */
-	public function isAssociative() {
+	public function isAssociative(): ?bool {
 		return $this->isAssociative;
 	}
 
@@ -337,7 +320,7 @@ class Diff extends ArrayObject implements DiffOp {
 		return [
 			'type' => $this->getType(),
 			'isassoc' => $this->isAssociative,
-			'operations' => $operations
+			'operations' => $operations,
 		];
 	}
 
@@ -348,7 +331,7 @@ class Diff extends ArrayObject implements DiffOp {
 	 *
 	 * @return bool
 	 */
-	public function equals( $target ) {
+	public function equals( $target ): bool {
 		if ( $target === $this ) {
 			return true;
 		}
@@ -383,7 +366,7 @@ class Diff extends ArrayObject implements DiffOp {
 	 *
 	 * @param mixed $value
 	 */
-	public function append( $value ) {
+	public function append( $value ): void {
 		$this->setElement( null, $value );
 	}
 
@@ -395,7 +378,7 @@ class Diff extends ArrayObject implements DiffOp {
 	 * @param int|string $index
 	 * @param mixed $value
 	 */
-	public function offsetSet( $index, $value ) {
+	public function offsetSet( $index, $value ): void {
 		$this->setElement( $index, $value );
 	}
 
@@ -413,7 +396,7 @@ class Diff extends ArrayObject implements DiffOp {
 	 *
 	 * @throws InvalidArgumentException
 	 */
-	private function setElement( $index, $value ) {
+	private function setElement( $index, $value ): void {
 		if ( !( $value instanceof DiffOp ) ) {
 			throw new InvalidArgumentException(
 				'Can only add DiffOp implementing objects to ' . get_called_class() . '.'
@@ -429,24 +412,15 @@ class Diff extends ArrayObject implements DiffOp {
 		}
 	}
 
-	/**
-	 * @see Serializable::serialize
-	 *
-	 * @since 0.1
-	 *
-	 * @return string
-	 */
-	public function serialize() {
+	public function __serialize(): array {
 		$assoc = $this->isAssociative === null ? 'n' : ( $this->isAssociative ? 't' : 'f' );
 
-		$data = [
+		return [
 			'data' => $this->getArrayCopy(),
 			'index' => $this->indexOffset,
 			'typePointers' => $this->typePointers,
-			'assoc' => $assoc
+			'assoc' => $assoc,
 		];
-
-		return serialize( $data );
 	}
 
 	/**

--- a/src/DiffOp/Diff/Diff.php
+++ b/src/DiffOp/Diff/Diff.php
@@ -145,27 +145,21 @@ class Diff extends ArrayObject implements DiffOp {
 	 *
 	 * @param string $serialization
 	 */
-	public function unserialize( $serialization ): void {
-		$this->__unserialize( $serialization );
-	}
+	public function unserialize( $serialization ) {
+		$serializationData = unserialize( $serialization );
 
-	/**
-	 * @param string $serialization
-	 */
-	public function __unserialize( $serialization ): void {
-		/** @var array $serialization */
-		foreach ( $serialization['data'] as $offset => $value ) {
+		foreach ( $serializationData['data'] as $offset => $value ) {
 			// Just set the element, bypassing checks and offset resolving,
 			// as these elements have already gone through this.
 			parent::offsetSet( $offset, $value );
 		}
 
-		$this->indexOffset = $serialization['index'];
+		$this->indexOffset = $serializationData['index'];
 
-		$this->typePointers = $serialization['typePointers'];
+		$this->typePointers = $serializationData['typePointers'];
 
-		if ( array_key_exists( 'assoc', $serialization ) ) {
-			$this->isAssociative = $serialization['assoc'] === 'n' ? null : $serialization['assoc'] === 't';
+		if ( array_key_exists( 'assoc', $serializationData ) ) {
+			$this->isAssociative = $serializationData['assoc'] === 'n' ? null : $serializationData['assoc'] === 't';
 		}
 	}
 
@@ -343,7 +337,7 @@ class Diff extends ArrayObject implements DiffOp {
 		return [
 			'type' => $this->getType(),
 			'isassoc' => $this->isAssociative,
-			'operations' => $operations,
+			'operations' => $operations
 		];
 	}
 
@@ -389,7 +383,7 @@ class Diff extends ArrayObject implements DiffOp {
 	 *
 	 * @param mixed $value
 	 */
-	public function append( $value ): void {
+	public function append( $value ) {
 		$this->setElement( null, $value );
 	}
 
@@ -401,7 +395,7 @@ class Diff extends ArrayObject implements DiffOp {
 	 * @param int|string $index
 	 * @param mixed $value
 	 */
-	public function offsetSet( $index, $value ): void {
+	public function offsetSet( $index, $value ) {
 		$this->setElement( $index, $value );
 	}
 
@@ -442,22 +436,17 @@ class Diff extends ArrayObject implements DiffOp {
 	 *
 	 * @return string
 	 */
-	public function serialize(): string {
-		return serialize( $this->__serialize() );
-	}
-
-	/**
-	 * @return array
-	 */
-	public function __serialize(): array {
+	public function serialize() {
 		$assoc = $this->isAssociative === null ? 'n' : ( $this->isAssociative ? 't' : 'f' );
 
-		return [
+		$data = [
 			'data' => $this->getArrayCopy(),
 			'index' => $this->indexOffset,
 			'typePointers' => $this->typePointers,
-			'assoc' => $assoc,
+			'assoc' => $assoc
 		];
+
+		return serialize( $data );
 	}
 
 	/**

--- a/src/DiffOp/DiffOp.php
+++ b/src/DiffOp/DiffOp.php
@@ -5,7 +5,6 @@ declare( strict_types = 1 );
 namespace Diff\DiffOp;
 
 use Countable;
-use Serializable;
 
 /**
  * Interface for diff operations. A diff operation
@@ -18,7 +17,7 @@ use Serializable;
  * @license BSD-3-Clause
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-interface DiffOp extends Serializable, Countable {
+interface DiffOp extends Countable {
 
 	/**
 	 * Returns a string identifier for the operation type.
@@ -59,6 +58,6 @@ interface DiffOp extends Serializable, Countable {
 	 *
 	 * @return array
 	 */
-	public function toArray( callable $valueConverter = null ): array;
+	public function toArray( ?callable $valueConverter = null ): array;
 
 }

--- a/src/DiffOp/DiffOpAdd.php
+++ b/src/DiffOp/DiffOpAdd.php
@@ -46,26 +46,12 @@ class DiffOpAdd extends AtomicDiffOp {
 		return $this->newValue;
 	}
 
-	/**
-	 * @see Serializable::serialize
-	 *
-	 * @since 0.1
-	 *
-	 * @return string|null
-	 */
-	public function serialize() {
-		return serialize( $this->newValue );
+	public function __serialize(): array {
+		return [ $this->newValue ];
 	}
 
-	/**
-	 * @see Serializable::unserialize
-	 *
-	 * @since 0.1
-	 *
-	 * @param string $serialization
-	 */
-	public function unserialize( $serialization ) {
-		$this->newValue = unserialize( $serialization );
+	public function __unserialize( array $serialization ): void {
+		[ $this->newValue ] = $serialization;
 	}
 
 	/**
@@ -78,7 +64,7 @@ class DiffOpAdd extends AtomicDiffOp {
 	 *
 	 * @return array
 	 */
-	public function toArray( callable $valueConverter = null ): array {
+	public function toArray( ?callable $valueConverter = null ): array {
 		return [
 			'type' => $this->getType(),
 			'newvalue' => $this->objectToArray( $this->newValue, $valueConverter ),

--- a/src/DiffOp/DiffOpAdd.php
+++ b/src/DiffOp/DiffOpAdd.php
@@ -54,11 +54,7 @@ class DiffOpAdd extends AtomicDiffOp {
 	 * @return string|null
 	 */
 	public function serialize() {
-		return serialize( $this->__serialize() );
-	}
-
-	public function __serialize(): array {
-		return [ $this->newValue ];
+		return serialize( $this->newValue );
 	}
 
 	/**
@@ -68,12 +64,8 @@ class DiffOpAdd extends AtomicDiffOp {
 	 *
 	 * @param string $serialization
 	 */
-	public function unserialize( $serialization ): void {
-		$this->__unserialize( $serialization );
-	}
-
-	public function __unserialize( $serialization ): void {
-		[ $this->newValue ] = $serialization;
+	public function unserialize( $serialization ) {
+		$this->newValue = unserialize( $serialization );
 	}
 
 	/**

--- a/src/DiffOp/DiffOpAdd.php
+++ b/src/DiffOp/DiffOpAdd.php
@@ -54,7 +54,11 @@ class DiffOpAdd extends AtomicDiffOp {
 	 * @return string|null
 	 */
 	public function serialize() {
-		return serialize( $this->newValue );
+		return serialize( $this->__serialize() );
+	}
+
+	public function __serialize(): array {
+		return [ $this->newValue ];
 	}
 
 	/**
@@ -64,8 +68,12 @@ class DiffOpAdd extends AtomicDiffOp {
 	 *
 	 * @param string $serialization
 	 */
-	public function unserialize( $serialization ) {
-		$this->newValue = unserialize( $serialization );
+	public function unserialize( $serialization ): void {
+		$this->__unserialize( $serialization );
+	}
+
+	public function __unserialize( $serialization ): void {
+		[ $this->newValue ] = $serialization;
 	}
 
 	/**

--- a/src/DiffOp/DiffOpChange.php
+++ b/src/DiffOp/DiffOpChange.php
@@ -66,11 +66,7 @@ class DiffOpChange extends AtomicDiffOp {
 	 * @return string|null
 	 */
 	public function serialize() {
-		return serialize( $this->__serialize() );
-	}
-
-	public function __serialize() {
-		return [ $this->newValue, $this->oldValue ];
+		return serialize( [ $this->newValue, $this->oldValue ] );
 	}
 
 	/**
@@ -80,15 +76,8 @@ class DiffOpChange extends AtomicDiffOp {
 	 *
 	 * @param string $serialization
 	 */
-	public function unserialize( $serialization ): void {
-		$this->__unserialize( $serialization );
-	}
-
-	/**
-	 * @param string $serialization
-	 */
-	public function __unserialize( $serialization ): void {
-		[ $this->newValue, $this->oldValue ] = $serialization;
+	public function unserialize( $serialization ) {
+		list( $this->newValue, $this->oldValue ) = unserialize( $serialization );
 	}
 
 	/**

--- a/src/DiffOp/DiffOpChange.php
+++ b/src/DiffOp/DiffOpChange.php
@@ -58,26 +58,12 @@ class DiffOpChange extends AtomicDiffOp {
 		return $this->newValue;
 	}
 
-	/**
-	 * @see Serializable::serialize
-	 *
-	 * @since 0.1
-	 *
-	 * @return string|null
-	 */
-	public function serialize() {
-		return serialize( [ $this->newValue, $this->oldValue ] );
+	public function __serialize(): array {
+		return [ $this->newValue, $this->oldValue ];
 	}
 
-	/**
-	 * @see Serializable::unserialize
-	 *
-	 * @since 0.1
-	 *
-	 * @param string $serialization
-	 */
-	public function unserialize( $serialization ) {
-		list( $this->newValue, $this->oldValue ) = unserialize( $serialization );
+	public function __unserialize( array $serialization ): void {
+		[ $this->newValue, $this->oldValue ] = $serialization;
 	}
 
 	/**

--- a/src/DiffOp/DiffOpChange.php
+++ b/src/DiffOp/DiffOpChange.php
@@ -66,7 +66,11 @@ class DiffOpChange extends AtomicDiffOp {
 	 * @return string|null
 	 */
 	public function serialize() {
-		return serialize( [ $this->newValue, $this->oldValue ] );
+		return serialize( $this->__serialize() );
+	}
+
+	public function __serialize() {
+		return [ $this->newValue, $this->oldValue ];
 	}
 
 	/**
@@ -76,8 +80,15 @@ class DiffOpChange extends AtomicDiffOp {
 	 *
 	 * @param string $serialization
 	 */
-	public function unserialize( $serialization ) {
-		list( $this->newValue, $this->oldValue ) = unserialize( $serialization );
+	public function unserialize( $serialization ): void {
+		$this->__unserialize( $serialization );
+	}
+
+	/**
+	 * @param string $serialization
+	 */
+	public function __unserialize( $serialization ): void {
+		[ $this->newValue, $this->oldValue ] = $serialization;
 	}
 
 	/**

--- a/src/DiffOp/DiffOpRemove.php
+++ b/src/DiffOp/DiffOpRemove.php
@@ -54,11 +54,7 @@ class DiffOpRemove extends AtomicDiffOp {
 	 * @return string|null
 	 */
 	public function serialize() {
-		return serialize( $this->__serialize() );
-	}
-
-	public function __serialize() {
-		return [ $this->oldValue ];
+		return serialize( $this->oldValue );
 	}
 
 	/**
@@ -68,15 +64,8 @@ class DiffOpRemove extends AtomicDiffOp {
 	 *
 	 * @param string $serialization
 	 */
-	public function unserialize( $serialization ): void {
-		$this->__unserialize( $serialization );
-	}
-
-	/**
-	 * @param string $serialization
-	 */
-	public function __unserialize( $serialization ): void {
-		[ $this->oldValue ] = $serialization;
+	public function unserialize( $serialization ) {
+		$this->oldValue = unserialize( $serialization );
 	}
 
 	/**

--- a/src/DiffOp/DiffOpRemove.php
+++ b/src/DiffOp/DiffOpRemove.php
@@ -54,7 +54,11 @@ class DiffOpRemove extends AtomicDiffOp {
 	 * @return string|null
 	 */
 	public function serialize() {
-		return serialize( $this->oldValue );
+		return serialize( $this->__serialize() );
+	}
+
+	public function __serialize() {
+		return [ $this->oldValue ];
 	}
 
 	/**
@@ -64,8 +68,15 @@ class DiffOpRemove extends AtomicDiffOp {
 	 *
 	 * @param string $serialization
 	 */
-	public function unserialize( $serialization ) {
-		$this->oldValue = unserialize( $serialization );
+	public function unserialize( $serialization ): void {
+		$this->__unserialize( $serialization );
+	}
+
+	/**
+	 * @param string $serialization
+	 */
+	public function __unserialize( $serialization ): void {
+		[ $this->oldValue ] = $serialization;
 	}
 
 	/**

--- a/src/DiffOp/DiffOpRemove.php
+++ b/src/DiffOp/DiffOpRemove.php
@@ -46,26 +46,12 @@ class DiffOpRemove extends AtomicDiffOp {
 		return $this->oldValue;
 	}
 
-	/**
-	 * @see Serializable::serialize
-	 *
-	 * @since 0.1
-	 *
-	 * @return string|null
-	 */
-	public function serialize() {
-		return serialize( $this->oldValue );
+	public function __serialize(): array {
+		return [ $this->oldValue ];
 	}
 
-	/**
-	 * @see Serializable::unserialize
-	 *
-	 * @since 0.1
-	 *
-	 * @param string $serialization
-	 */
-	public function unserialize( $serialization ) {
-		$this->oldValue = unserialize( $serialization );
+	public function __unserialize( array $serialization ): void {
+		[ $this->oldValue ] = $serialization;
 	}
 
 	/**
@@ -78,7 +64,7 @@ class DiffOpRemove extends AtomicDiffOp {
 	 *
 	 * @return array
 	 */
-	public function toArray( callable $valueConverter = null ): array {
+	public function toArray( ?callable $valueConverter = null ): array {
 		return [
 			'type' => $this->getType(),
 			'oldvalue' => $this->objectToArray( $this->oldValue, $valueConverter ),

--- a/src/DiffOpFactory.php
+++ b/src/DiffOpFactory.php
@@ -32,7 +32,7 @@ class DiffOpFactory {
 	 * @param callable|null $valueConverter optional callback used to convert special
 	 *        array structures into objects used as values in atomic diff ops.
 	 */
-	public function __construct( $valueConverter = null ) {
+	public function __construct( ?callable $valueConverter = null ) {
 		$this->valueConverter = $valueConverter;
 	}
 
@@ -93,7 +93,7 @@ class DiffOpFactory {
 	 *
 	 * @throws InvalidArgumentException
 	 */
-	protected function assertHasKey( $key, array $diffOp ) {
+	protected function assertHasKey( string $key, array $diffOp ): void {
 		if ( !array_key_exists( $key, $diffOp ) ) {
 			throw new InvalidArgumentException( 'Invalid array provided. Missing key "' . $key . '"' );
 		}

--- a/src/Differ/CallbackListDiffer.php
+++ b/src/Differ/CallbackListDiffer.php
@@ -21,10 +21,7 @@ use Diff\DiffOp\DiffOp;
  */
 class CallbackListDiffer implements Differ {
 
-	/**
-	 * @var ListDiffer
-	 */
-	private $differ;
+	private ListDiffer $differ;
 
 	/**
 	 * @since 0.5

--- a/src/Differ/MapDiffer.php
+++ b/src/Differ/MapDiffer.php
@@ -25,25 +25,16 @@ use LogicException;
  */
 class MapDiffer implements Differ {
 
-	/**
-	 * @var bool
-	 */
-	private $recursively;
+	private bool $recursively;
 
-	/**
-	 * @var Differ
-	 */
-	private $listDiffer;
+	private Differ $listDiffer;
 
-	/**
-	 * @var ValueComparer
-	 */
-	private $valueComparer;
+	private ValueComparer $valueComparer;
 
 	/**
 	 * The third argument ($comparer) was added in 3.0
 	 */
-	public function __construct( bool $recursively = false, Differ $listDiffer = null, ValueComparer $comparer = null ) {
+	public function __construct( bool $recursively = false, ?Differ $listDiffer = null, ?ValueComparer $comparer = null ) {
 		$this->recursively = $recursively;
 		$this->listDiffer = $listDiffer ?? new ListDiffer();
 		$this->valueComparer = $comparer ?? new StrictComparer();
@@ -118,7 +109,7 @@ class MapDiffer implements Differ {
 		// @codeCoverageIgnoreEnd
 	}
 
-	private function getDiffOpForElementRecursively( $key, array $oldSet, array $newSet ) {
+	private function getDiffOpForElementRecursively( $key, array $oldSet, array $newSet ): ?Diff {
 		$old = array_key_exists( $key, $oldSet ) ? $oldSet[$key] : [];
 		$new = array_key_exists( $key, $newSet ) ? $newSet[$key] : [];
 

--- a/src/Differ/OrderedListDiffer.php
+++ b/src/Differ/OrderedListDiffer.php
@@ -22,10 +22,7 @@ use Diff\DiffOp\DiffOp;
  */
 class OrderedListDiffer implements Differ {
 
-	/**
-	 * @var ListDiffer
-	 */
-	private $differ;
+	private ListDiffer $differ;
 
 	/**
 	 * @since 0.9

--- a/src/Patcher/MapPatcher.php
+++ b/src/Patcher/MapPatcher.php
@@ -22,15 +22,9 @@ use Diff\DiffOp\DiffOpRemove;
  */
 class MapPatcher extends ThrowingPatcher {
 
-	/**
-	 * @var Patcher
-	 */
-	private $listPatcher;
+	private Patcher $listPatcher;
 
-	/**
-	 * @var ValueComparer|null
-	 */
-	private $comparer = null;
+	private ?ValueComparer $comparer = null;
 
 	/**
 	 * @since 0.4
@@ -38,7 +32,7 @@ class MapPatcher extends ThrowingPatcher {
 	 * @param bool $throwErrors
 	 * @param Patcher|null $listPatcher The patcher that will be used for lists in the value
 	 */
-	public function __construct( bool $throwErrors = false, Patcher $listPatcher = null ) {
+	public function __construct( bool $throwErrors = false, ?Patcher $listPatcher = null ) {
 		parent::__construct( $throwErrors );
 
 		$this->listPatcher = $listPatcher ?: new ListPatcher( $throwErrors );
@@ -77,7 +71,7 @@ class MapPatcher extends ThrowingPatcher {
 	 *
 	 * @throws PatcherException
 	 */
-	private function applyOperation( array &$base, $key, DiffOp $diffOp ) {
+	private function applyOperation( array &$base, $key, DiffOp $diffOp ): void {
 		if ( $diffOp instanceof DiffOpAdd ) {
 			$this->applyDiffOpAdd( $base, $key, $diffOp );
 		}
@@ -102,7 +96,7 @@ class MapPatcher extends ThrowingPatcher {
 	 *
 	 * @throws PatcherException
 	 */
-	private function applyDiffOpAdd( array &$base, $key, DiffOpAdd $diffOp ) {
+	private function applyDiffOpAdd( array &$base, $key, DiffOpAdd $diffOp ): void {
 		if ( array_key_exists( $key, $base ) ) {
 			$this->handleError( 'Cannot add an element already present in a map' );
 			return;
@@ -118,7 +112,7 @@ class MapPatcher extends ThrowingPatcher {
 	 *
 	 * @throws PatcherException
 	 */
-	private function applyDiffOpRemove( array &$base, $key, DiffOpRemove $diffOp ) {
+	private function applyDiffOpRemove( array &$base, $key, DiffOpRemove $diffOp ): void {
 		if ( !array_key_exists( $key, $base ) ) {
 			$this->handleError( 'Cannot do a non-add operation with an element not present in a map' );
 			return;
@@ -139,7 +133,7 @@ class MapPatcher extends ThrowingPatcher {
 	 *
 	 * @throws PatcherException
 	 */
-	private function applyDiffOpChange( array &$base, $key, DiffOpChange $diffOp ) {
+	private function applyDiffOpChange( array &$base, $key, DiffOpChange $diffOp ): void {
 		if ( !array_key_exists( $key, $base ) ) {
 			$this->handleError( 'Cannot do a non-add operation with an element not present in a map' );
 			return;
@@ -160,7 +154,7 @@ class MapPatcher extends ThrowingPatcher {
 	 *
 	 * @throws PatcherException
 	 */
-	private function applyDiff( &$base, $key, Diff $diffOp ) {
+	private function applyDiff( &$base, $key, Diff $diffOp ): void {
 		if ( $this->isAttemptToModifyNotExistingElement( $base, $key, $diffOp ) ) {
 			$this->handleError( 'Cannot apply a diff with non-add operations to an element not present in a map' );
 			return;
@@ -180,7 +174,7 @@ class MapPatcher extends ThrowingPatcher {
 	 *
 	 * @return bool
 	 */
-	private function isAttemptToModifyNotExistingElement( $base, $key, Diff $diffOp ): bool {
+	private function isAttemptToModifyNotExistingElement( array $base, $key, Diff $diffOp ): bool {
 		return !array_key_exists( $key, $base )
 			&& ( $diffOp->getChanges() !== [] || $diffOp->getRemovals() !== [] );
 	}
@@ -220,7 +214,7 @@ class MapPatcher extends ThrowingPatcher {
 	 *
 	 * @param ValueComparer $comparer
 	 */
-	public function setValueComparer( ValueComparer $comparer ) {
+	public function setValueComparer( ValueComparer $comparer ): void {
 		$this->comparer = $comparer;
 	}
 

--- a/src/Patcher/PreviewablePatcher.php
+++ b/src/Patcher/PreviewablePatcher.php
@@ -31,6 +31,6 @@ interface PreviewablePatcher extends Patcher {
 	 *
 	 * @return Diff
 	 */
-	public function getApplicableDiff( array $base, Diff $diffOps );
+	public function getApplicableDiff( array $base, Diff $diffOps ): Diff;
 
 }

--- a/src/Patcher/ThrowingPatcher.php
+++ b/src/Patcher/ThrowingPatcher.php
@@ -41,7 +41,7 @@ abstract class ThrowingPatcher implements PreviewablePatcher {
 	 *
 	 * @throws PatcherException
 	 */
-	protected function handleError( string $message ) {
+	protected function handleError( string $message ): void {
 		if ( $this->throwErrors ) {
 			throw new PatcherException( $message );
 		}
@@ -52,7 +52,7 @@ abstract class ThrowingPatcher implements PreviewablePatcher {
 	 *
 	 * @since 0.4
 	 */
-	public function ignoreErrors() {
+	public function ignoreErrors(): void {
 		$this->throwErrors = false;
 	}
 
@@ -61,7 +61,7 @@ abstract class ThrowingPatcher implements PreviewablePatcher {
 	 *
 	 * @since 0.4
 	 */
-	public function throwErrors() {
+	public function throwErrors(): void {
 		$this->throwErrors = true;
 	}
 

--- a/tests/unit/ArrayComparer/NativeArrayComparerTest.php
+++ b/tests/unit/ArrayComparer/NativeArrayComparerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace Diff\Tests\ArrayComparer;
 
@@ -8,59 +8,59 @@ use Diff\ArrayComparer\NativeArrayComparer;
 use Diff\Tests\DiffTestCase;
 
 /**
- * @covers \Diff\ArrayComparer\NativeArrayComparer
+ * @covers  \Diff\ArrayComparer\NativeArrayComparer
  *
- * @group Diff
+ * @group   Diff
  *
  * @license BSD-3-Clause
- * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author  Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class NativeArrayComparerTest extends DiffTestCase {
 
-	public function testCanConstruct() {
+	public function testCanConstruct(): void {
 		new NativeArrayComparer();
-		$this->assertTrue( true );
+		$this->assertTrue(true);
 	}
 
 	/**
 	 * @dataProvider diffInputProvider
 	 */
-	public function testDiffArraysReturnsTheNativeValue( array $arrayOne, array $arrayTwo ) {
+	public function testDiffArraysReturnsTheNativeValue(array $arrayOne, array $arrayTwo): void {
 		$differ = new NativeArrayComparer();
 
 		$this->assertEquals(
-			array_diff( $arrayOne, $arrayTwo ),
-			$differ->diffArrays( $arrayOne, $arrayTwo )
+			array_diff($arrayOne, $arrayTwo),
+			$differ->diffArrays($arrayOne, $arrayTwo)
 		);
 	}
 
-	public function diffInputProvider() {
-		$argLists = array();
+	public function diffInputProvider(): array {
+		$argLists = [];
 
-		$argLists[] = array(
-			array(),
-			array(),
-		);
+		$argLists[] = [
+			[],
+			[],
+		];
 
-		$argLists[] = array(
-			array( 'foo', 1 ),
-			array( 'foo', 1 ),
-		);
+		$argLists[] = [
+			['foo', 1],
+			['foo', 1],
+		];
 
-		$argLists[] = array(
-			array( 'bar', 2 ),
-			array( 'foo', 1 ),
-		);
+		$argLists[] = [
+			['bar', 2],
+			['foo', 1],
+		];
 
-		$argLists[] = array(
-			array( 1, 'bar', 2, 1 ),
-			array( 'foo', 1, 3 ),
-		);
+		$argLists[] = [
+			[1, 'bar', 2, 1],
+			['foo', 1, 3],
+		];
 
-		$argLists[] = array(
-			array( '', null, 2, false , 0 ),
-			array( '0', true, 1, ' ', '' ),
-		);
+		$argLists[] = [
+			['', null, 2, false, 0],
+			['0', true, 1, ' ', ''],
+		];
 
 		return $argLists;
 	}

--- a/tests/unit/ArrayComparer/OrderedArrayComparerTest.php
+++ b/tests/unit/ArrayComparer/OrderedArrayComparerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace Diff\Tests\ArrayComparer;
 
@@ -9,66 +9,66 @@ use Diff\ArrayComparer\OrderedArrayComparer;
 use Diff\Tests\DiffTestCase;
 
 /**
- * @covers \Diff\ArrayComparer\OrderedArrayComparer
+ * @covers  \Diff\ArrayComparer\OrderedArrayComparer
  *
- * @since 0.9
+ * @since   0.9
  *
- * @group Diff
+ * @group   Diff
  *
  * @license BSD-3-Clause
- * @author Jeroen De Dauw < jeroendedauw@gmail.com >
- * @author Tobias Gritschacher < tobias.gritschacher@wikimedia.de >
+ * @author  Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author  Tobias Gritschacher < tobias.gritschacher@wikimedia.de >
  */
 class OrderedArrayComparerTest extends DiffTestCase {
 
-	public function testCanConstruct() {
-		new OrderedArrayComparer( $this->createMock( 'Diff\Comparer\ValueComparer' ) );
-		$this->assertTrue( true );
+	public function testCanConstruct(): void {
+		new OrderedArrayComparer($this->createMock('Diff\Comparer\ValueComparer'));
+		$this->assertTrue(true);
 	}
 
-	public function testDiffArraysWithComparerThatAlwaysReturnsTrue() {
-		$valueComparer = $this->createMock( 'Diff\Comparer\ValueComparer' );
+	public function testDiffArraysWithComparerThatAlwaysReturnsTrue(): void {
+		$valueComparer = $this->createMock('Diff\Comparer\ValueComparer');
 
-		$valueComparer->expects( $this->any() )
-			->method( 'valuesAreEqual' )
-			->will( $this->returnValue( true ) );
+		$valueComparer->expects($this->any())
+			->method('valuesAreEqual')
+			->will($this->returnValue(true));
 
-		$arrayComparer = new OrderedArrayComparer( $valueComparer );
+		$arrayComparer = new OrderedArrayComparer($valueComparer);
 
 		$this->assertNoDifference(
 			$arrayComparer,
-			array( 0, 2, 4 ),
-			array( 1, 2, 9 )
+			[0, 2, 4],
+			[1, 2, 9]
 		);
 
 		$this->assertNoDifference(
 			$arrayComparer,
-			array( 1, 2, 3 ),
-			array( 1, 2, 3 )
+			[1, 2, 3],
+			[1, 2, 3]
 		);
 
 		$this->assertNoDifference(
 			$arrayComparer,
-			array( 'bah' ),
-			array( 'foo', 'bar', 'baz' )
+			['bah'],
+			['foo', 'bar', 'baz']
 		);
 
 		$this->assertNoDifference(
 			$arrayComparer,
-			array(),
-			array( 'foo', 'bar', 'baz' )
+			[],
+			['foo', 'bar', 'baz']
 		);
 
 		$this->assertNoDifference(
 			$arrayComparer,
-			array(),
-			array()
+			[],
+			[]
 		);
 	}
 
-	private function assertNoDifference( ArrayComparer $arrayComparer, array $arrayOne, array $arrayTwo ) {
+	private function assertNoDifference(ArrayComparer $arrayComparer, array $arrayOne, array $arrayTwo): void {
 		$this->assertEquals(
-			array(),
+			[],
 			$arrayComparer->diffArrays(
 				$arrayOne,
 				$arrayTwo
@@ -76,41 +76,41 @@ class OrderedArrayComparerTest extends DiffTestCase {
 		);
 	}
 
-	public function testDiffArraysWithComparerThatAlwaysReturnsFalse() {
-		$valueComparer = $this->createMock( 'Diff\Comparer\ValueComparer' );
+	public function testDiffArraysWithComparerThatAlwaysReturnsFalse(): void {
+		$valueComparer = $this->createMock('Diff\Comparer\ValueComparer');
 
-		$valueComparer->expects( $this->any() )
-			->method( 'valuesAreEqual' )
-			->will( $this->returnValue( false ) );
+		$valueComparer->expects($this->any())
+			->method('valuesAreEqual')
+			->will($this->returnValue(false));
 
-		$arrayComparer = new OrderedArrayComparer( $valueComparer );
+		$arrayComparer = new OrderedArrayComparer($valueComparer);
 
 		$this->assertAllDifferent(
 			$arrayComparer,
-			array(),
-			array()
+			[],
+			[]
 		);
 
 		$this->assertAllDifferent(
 			$arrayComparer,
-			array( 1, 2, 3 ),
-			array()
+			[1, 2, 3],
+			[]
 		);
 
 		$this->assertAllDifferent(
 			$arrayComparer,
-			array( 1, 2, 3 ),
-			array( 1, 2, 3 )
+			[1, 2, 3],
+			[1, 2, 3]
 		);
 
 		$this->assertAllDifferent(
 			$arrayComparer,
-			array(),
-			array( 1, 2, 3 )
+			[],
+			[1, 2, 3]
 		);
 	}
 
-	private function assertAllDifferent( ArrayComparer $arrayComparer, array $arrayOne, array $arrayTwo ) {
+	private function assertAllDifferent(ArrayComparer $arrayComparer, array $arrayOne, array $arrayTwo): void {
 		$this->assertEquals(
 			$arrayOne,
 			$arrayComparer->diffArrays(
@@ -120,136 +120,140 @@ class OrderedArrayComparerTest extends DiffTestCase {
 		);
 	}
 
-	public function testQuantityMattersWithReturnTrue() {
-		$valueComparer = $this->createMock( 'Diff\Comparer\ValueComparer' );
+	public function testQuantityMattersWithReturnTrue(): void {
+		$valueComparer = $this->createMock('Diff\Comparer\ValueComparer');
 
-		$valueComparer->expects( $this->any() )
-			->method( 'valuesAreEqual' )
-			->will( $this->returnValue( true ) );
+		$valueComparer->expects($this->any())
+			->method('valuesAreEqual')
+			->will($this->returnValue(true));
 
-		$arrayComparer = new OrderedArrayComparer( $valueComparer );
+		$arrayComparer = new OrderedArrayComparer($valueComparer);
 
 		$this->assertEquals(
-			array( 1, 1, 1 ),
+			[1, 1, 1],
 			$arrayComparer->diffArrays(
-				array( 1, 1, 1, 1 ),
-				array( 1 )
+				[1, 1, 1, 1],
+				[1]
 			)
 		);
 
 		$this->assertEquals(
-			array( 1 ),
+			[1],
 			$arrayComparer->diffArrays(
-				array( 1, 1, 1, 1 ),
-				array( 1, 1, 1  )
-			)
-		);
-	}
-
-	public function testQuantityMattersWithSimpleComparison() {
-		$valueComparer = $this->createMock( 'Diff\Comparer\ValueComparer' );
-
-		$valueComparer->expects( $this->any() )
-			->method( 'valuesAreEqual' )
-			->will( $this->returnCallback( function( $firstValue, $secondValue ) {
-				return $firstValue == $secondValue;
-			} ) );
-
-		$arrayComparer = new OrderedArrayComparer( $valueComparer );
-
-		$this->assertEquals(
-			array( 1, 2, 3, 2, 5 ),
-			$arrayComparer->diffArrays(
-				array( 1, 1, 2, 3, 2, 5 ),
-				array( 1, 2, 3, 4  )
-			)
-		);
-
-		$this->assertEquals(
-			array( 1, 2 ),
-			$arrayComparer->diffArrays(
-				array( 1, 1, 1, 2, 2, 3 ),
-				array( 1, 1, 2, 2, 3, 3, 3 )
-			)
-		);
-
-		$this->assertEquals(
-			array( 3, 1, 2, 1, 1, 2 ),
-			$arrayComparer->diffArrays(
-				array( 3, 1, 2, 1, 1, 2 ),
-				array( 1, 3, 3, 2, 2, 3, 1 )
+				[1, 1, 1, 1],
+				[1, 1, 1]
 			)
 		);
 	}
 
-	public function testOrderMattersWithSimpleComparison() {
-		$valueComparer = $this->createMock( 'Diff\Comparer\ValueComparer' );
+	public function testQuantityMattersWithSimpleComparison(): void {
+		$valueComparer = $this->createMock('Diff\Comparer\ValueComparer');
 
-		$valueComparer->expects( $this->any() )
-			->method( 'valuesAreEqual' )
-			->will( $this->returnCallback( function( $firstValue, $secondValue ) {
-				return $firstValue == $secondValue;
-			} ) );
+		$valueComparer->expects($this->any())
+			->method('valuesAreEqual')
+			->will(
+				$this->returnCallback(function ($firstValue, $secondValue) {
+					return $firstValue == $secondValue;
+				})
+			);
 
-		$arrayComparer = new OrderedArrayComparer( $valueComparer );
+		$arrayComparer = new OrderedArrayComparer($valueComparer);
 
 		$this->assertEquals(
-			array(),
+			[1, 2, 3, 2, 5],
 			$arrayComparer->diffArrays(
-				array( 1, 2, 3, 4, 5 ),
-				array( 1, 2, 3, 4, 5 )
+				[1, 1, 2, 3, 2, 5],
+				[1, 2, 3, 4]
 			)
 		);
 
 		$this->assertEquals(
-			array( 1, 2, 3, 4 ),
+			[1, 2],
 			$arrayComparer->diffArrays(
-				array( 1, 2, 3, 4, 5 ),
-				array( 2, 1, 4, 3, 5 )
+				[1, 1, 1, 2, 2, 3],
+				[1, 1, 2, 2, 3, 3, 3]
 			)
 		);
 
 		$this->assertEquals(
-			array( 1, 5 ),
+			[3, 1, 2, 1, 1, 2],
 			$arrayComparer->diffArrays(
-				array( 1, 2, 3, 4, 5 ),
-				array( 5, 2, 3, 4, 1 )
-			)
-		);
-
-		$this->assertEquals(
-			array( 1, 2, 3, 4, 5 ),
-			$arrayComparer->diffArrays(
-				array( 1, 2, 3, 4, 5 ),
-				array( 2, 3, 4, 5 )
-			)
-		);
-
-		$this->assertEquals(
-			array( 1, 2, 3, 4 ),
-			$arrayComparer->diffArrays(
-				array( 1, 2, 3, 4 ),
-				array( 5, 1, 2, 3, 4 )
+				[3, 1, 2, 1, 1, 2],
+				[1, 3, 3, 2, 2, 3, 1]
 			)
 		);
 	}
 
-	public function testValueComparerGetsCalledWithCorrectValues() {
-		$valueComparer = $this->createMock( 'Diff\Comparer\ValueComparer' );
+	public function testOrderMattersWithSimpleComparison(): void {
+		$valueComparer = $this->createMock('Diff\Comparer\ValueComparer');
 
-		$valueComparer->expects( $this->once() )
-			->method( 'valuesAreEqual' )
+		$valueComparer->expects($this->any())
+			->method('valuesAreEqual')
+			->will(
+				$this->returnCallback(function ($firstValue, $secondValue) {
+					return $firstValue == $secondValue;
+				})
+			);
+
+		$arrayComparer = new OrderedArrayComparer($valueComparer);
+
+		$this->assertEquals(
+			[],
+			$arrayComparer->diffArrays(
+				[1, 2, 3, 4, 5],
+				[1, 2, 3, 4, 5]
+			)
+		);
+
+		$this->assertEquals(
+			[1, 2, 3, 4],
+			$arrayComparer->diffArrays(
+				[1, 2, 3, 4, 5],
+				[2, 1, 4, 3, 5]
+			)
+		);
+
+		$this->assertEquals(
+			[1, 5],
+			$arrayComparer->diffArrays(
+				[1, 2, 3, 4, 5],
+				[5, 2, 3, 4, 1]
+			)
+		);
+
+		$this->assertEquals(
+			[1, 2, 3, 4, 5],
+			$arrayComparer->diffArrays(
+				[1, 2, 3, 4, 5],
+				[2, 3, 4, 5]
+			)
+		);
+
+		$this->assertEquals(
+			[1, 2, 3, 4],
+			$arrayComparer->diffArrays(
+				[1, 2, 3, 4],
+				[5, 1, 2, 3, 4]
+			)
+		);
+	}
+
+	public function testValueComparerGetsCalledWithCorrectValues(): void {
+		$valueComparer = $this->createMock('Diff\Comparer\ValueComparer');
+
+		$valueComparer->expects($this->once())
+			->method('valuesAreEqual')
 			->with(
-				$this->equalTo( 1 ),
-				$this->equalTo( 2 )
+				$this->equalTo(1),
+				$this->equalTo(2)
 			)
-			->will( $this->returnValue( true ) );
+			->will($this->returnValue(true));
 
-		$arrayComparer = new OrderedArrayComparer( $valueComparer );
+		$arrayComparer = new OrderedArrayComparer($valueComparer);
 
 		$arrayComparer->diffArrays(
-			array( 1 ),
-			array( 2 )
+			[1],
+			[2]
 		);
 	}
 

--- a/tests/unit/ArrayComparer/StrategicArrayComparerTest.php
+++ b/tests/unit/ArrayComparer/StrategicArrayComparerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace Diff\Tests\ArrayComparer;
 
@@ -9,63 +9,63 @@ use Diff\ArrayComparer\StrategicArrayComparer;
 use Diff\Tests\DiffTestCase;
 
 /**
- * @covers \Diff\ArrayComparer\StrategicArrayComparer
+ * @covers  \Diff\ArrayComparer\StrategicArrayComparer
  *
- * @group Diff
+ * @group   Diff
  *
  * @license BSD-3-Clause
- * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author  Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class StrategicArrayComparerTest extends DiffTestCase {
 
-	public function testCanConstruct() {
-		new StrategicArrayComparer( $this->createMock( 'Diff\Comparer\ValueComparer' ) );
-		$this->assertTrue( true );
+	public function testCanConstruct(): void {
+		new StrategicArrayComparer($this->createMock('Diff\Comparer\ValueComparer'));
+		$this->assertTrue(true);
 	}
 
-	public function testDiffArraysWithComparerThatAlwaysReturnsTrue() {
-		$valueComparer = $this->createMock( 'Diff\Comparer\ValueComparer' );
+	public function testDiffArraysWithComparerThatAlwaysReturnsTrue(): void {
+		$valueComparer = $this->createMock('Diff\Comparer\ValueComparer');
 
-		$valueComparer->expects( $this->any() )
-			->method( 'valuesAreEqual' )
-			->will( $this->returnValue( true ) );
+		$valueComparer->expects($this->any())
+			->method('valuesAreEqual')
+			->will($this->returnValue(true));
 
-		$arrayComparer = new StrategicArrayComparer( $valueComparer );
+		$arrayComparer = new StrategicArrayComparer($valueComparer);
 
 		$this->assertNoDifference(
 			$arrayComparer,
-			array( 0, 2, 4 ),
-			array( 1, 2, 9 )
+			[0, 2, 4],
+			[1, 2, 9]
 		);
 
 		$this->assertNoDifference(
 			$arrayComparer,
-			array( 1, 2, 3 ),
-			array( 1, 2, 3 )
+			[1, 2, 3],
+			[1, 2, 3]
 		);
 
 		$this->assertNoDifference(
 			$arrayComparer,
-			array( 'bah' ),
-			array( 'foo', 'bar', 'baz' )
+			['bah'],
+			['foo', 'bar', 'baz']
 		);
 
 		$this->assertNoDifference(
 			$arrayComparer,
-			array(),
-			array( 'foo', 'bar', 'baz' )
+			[],
+			['foo', 'bar', 'baz']
 		);
 
 		$this->assertNoDifference(
 			$arrayComparer,
-			array(),
-			array()
+			[],
+			[]
 		);
 	}
 
-	private function assertNoDifference( ArrayComparer $arrayComparer, array $arrayOne, array $arrayTwo ) {
+	private function assertNoDifference(ArrayComparer $arrayComparer, array $arrayOne, array $arrayTwo): void {
 		$this->assertEquals(
-			array(),
+			[],
 			$arrayComparer->diffArrays(
 				$arrayOne,
 				$arrayTwo
@@ -73,41 +73,41 @@ class StrategicArrayComparerTest extends DiffTestCase {
 		);
 	}
 
-	public function testDiffArraysWithComparerThatAlwaysReturnsFalse() {
-		$valueComparer = $this->createMock( 'Diff\Comparer\ValueComparer' );
+	public function testDiffArraysWithComparerThatAlwaysReturnsFalse(): void {
+		$valueComparer = $this->createMock('Diff\Comparer\ValueComparer');
 
-		$valueComparer->expects( $this->any() )
-			->method( 'valuesAreEqual' )
-			->will( $this->returnValue( false ) );
+		$valueComparer->expects($this->any())
+			->method('valuesAreEqual')
+			->will($this->returnValue(false));
 
-		$arrayComparer = new StrategicArrayComparer( $valueComparer );
+		$arrayComparer = new StrategicArrayComparer($valueComparer);
 
 		$this->assertAllDifferent(
 			$arrayComparer,
-			array(),
-			array()
+			[],
+			[]
 		);
 
 		$this->assertAllDifferent(
 			$arrayComparer,
-			array( 1, 2, 3 ),
-			array()
+			[1, 2, 3],
+			[]
 		);
 
 		$this->assertAllDifferent(
 			$arrayComparer,
-			array( 1, 2, 3 ),
-			array( 1, 2, 3 )
+			[1, 2, 3],
+			[1, 2, 3]
 		);
 
 		$this->assertAllDifferent(
 			$arrayComparer,
-			array(),
-			array( 1, 2, 3 )
+			[],
+			[1, 2, 3]
 		);
 	}
 
-	private function assertAllDifferent( ArrayComparer $arrayComparer, array $arrayOne, array $arrayTwo ) {
+	private function assertAllDifferent(ArrayComparer $arrayComparer, array $arrayOne, array $arrayTwo): void {
 		$this->assertEquals(
 			$arrayOne,
 			$arrayComparer->diffArrays(
@@ -117,84 +117,86 @@ class StrategicArrayComparerTest extends DiffTestCase {
 		);
 	}
 
-	public function testQuantityMattersWithReturnTrue() {
-		$valueComparer = $this->createMock( 'Diff\Comparer\ValueComparer' );
+	public function testQuantityMattersWithReturnTrue(): void {
+		$valueComparer = $this->createMock('Diff\Comparer\ValueComparer');
 
-		$valueComparer->expects( $this->any() )
-			->method( 'valuesAreEqual' )
-			->will( $this->returnValue( true ) );
+		$valueComparer->expects($this->any())
+			->method('valuesAreEqual')
+			->will($this->returnValue(true));
 
-		$arrayComparer = new StrategicArrayComparer( $valueComparer );
+		$arrayComparer = new StrategicArrayComparer($valueComparer);
 
 		$this->assertEquals(
-			array( 1, 1, 1 ),
+			[1, 1, 1],
 			$arrayComparer->diffArrays(
-				array( 1, 1, 1, 1 ),
-				array( 1 )
+				[1, 1, 1, 1],
+				[1]
 			)
 		);
 
 		$this->assertEquals(
-			array( 1 ),
+			[1],
 			$arrayComparer->diffArrays(
-				array( 1, 1, 1, 1 ),
-				array( 1, 1, 1  )
-			)
-		);
-	}
-
-	public function testQuantityMattersWithSimpleComparison() {
-		$valueComparer = $this->createMock( 'Diff\Comparer\ValueComparer' );
-
-		$valueComparer->expects( $this->any() )
-			->method( 'valuesAreEqual' )
-			->will( $this->returnCallback( function( $firstValue, $secondValue ) {
-				return $firstValue == $secondValue;
-			} ) );
-
-		$arrayComparer = new StrategicArrayComparer( $valueComparer );
-
-		$this->assertEquals(
-			array( 1, 2, 5 ),
-			$arrayComparer->diffArrays(
-				array( 1, 1, 2, 3, 2, 5 ),
-				array( 1, 2, 3, 4  )
-			)
-		);
-
-		$this->assertEquals(
-			array( 1 ),
-			$arrayComparer->diffArrays(
-				array( 1, 1, 1, 2, 2, 3 ),
-				array( 1, 1, 2, 2, 3, 3, 3 )
-			)
-		);
-
-		$this->assertEquals(
-			array( 1 ),
-			$arrayComparer->diffArrays(
-				array( 3, 1, 2, 1, 1, 2 ),
-				array( 1, 3, 3, 2, 2, 3, 1 )
+				[1, 1, 1, 1],
+				[1, 1, 1]
 			)
 		);
 	}
 
-	public function testValueComparerGetsCalledWithCorrectValues() {
-		$valueComparer = $this->createMock( 'Diff\Comparer\ValueComparer' );
+	public function testQuantityMattersWithSimpleComparison(): void {
+		$valueComparer = $this->createMock('Diff\Comparer\ValueComparer');
 
-		$valueComparer->expects( $this->once() )
-			->method( 'valuesAreEqual' )
+		$valueComparer->expects($this->any())
+			->method('valuesAreEqual')
+			->will(
+				$this->returnCallback(function ($firstValue, $secondValue) {
+					return $firstValue == $secondValue;
+				})
+			);
+
+		$arrayComparer = new StrategicArrayComparer($valueComparer);
+
+		$this->assertEquals(
+			[1, 2, 5],
+			$arrayComparer->diffArrays(
+				[1, 1, 2, 3, 2, 5],
+				[1, 2, 3, 4]
+			)
+		);
+
+		$this->assertEquals(
+			[1],
+			$arrayComparer->diffArrays(
+				[1, 1, 1, 2, 2, 3],
+				[1, 1, 2, 2, 3, 3, 3]
+			)
+		);
+
+		$this->assertEquals(
+			[1],
+			$arrayComparer->diffArrays(
+				[3, 1, 2, 1, 1, 2],
+				[1, 3, 3, 2, 2, 3, 1]
+			)
+		);
+	}
+
+	public function testValueComparerGetsCalledWithCorrectValues(): void {
+		$valueComparer = $this->createMock('Diff\Comparer\ValueComparer');
+
+		$valueComparer->expects($this->once())
+			->method('valuesAreEqual')
 			->with(
-				$this->equalTo( 1 ),
-				$this->equalTo( 2 )
+				$this->equalTo(1),
+				$this->equalTo(2)
 			)
-			->will( $this->returnValue( true ) );
+			->will($this->returnValue(true));
 
-		$arrayComparer = new StrategicArrayComparer( $valueComparer );
+		$arrayComparer = new StrategicArrayComparer($valueComparer);
 
 		$arrayComparer->diffArrays(
-			array( 1 ),
-			array( 2 )
+			[1],
+			[2]
 		);
 	}
 

--- a/tests/unit/ArrayComparer/StrictArrayComparerTest.php
+++ b/tests/unit/ArrayComparer/StrictArrayComparerTest.php
@@ -1,112 +1,113 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace Diff\Tests\ArrayComparer;
 
 use Diff\ArrayComparer\StrictArrayComparer;
 use Diff\Tests\DiffTestCase;
+use stdClass;
 
 /**
- * @covers \Diff\ArrayComparer\StrictArrayComparer
+ * @covers  \Diff\ArrayComparer\StrictArrayComparer
  *
- * @group Diff
+ * @group   Diff
  *
  * @license BSD-3-Clause
- * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author  Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class StrictArrayComparerTest extends DiffTestCase {
 
-	public function testCanConstruct() {
+	public function testCanConstruct(): void {
 		new StrictArrayComparer();
-		$this->assertTrue( true );
+		$this->assertTrue(true);
 	}
 
 	/**
 	 * @dataProvider diffInputProvider
 	 */
-	public function testDiffReturnsExpectedValue( array $arrayOne, array $arrayTwo, array $expected, $message = '' ) {
+	public function testDiffReturnsExpectedValue(array $arrayOne, array $arrayTwo, array $expected, $message = ''): void {
 		$differ = new StrictArrayComparer();
 
 		$this->assertEquals(
 			$expected,
-			$differ->diffArrays( $arrayOne, $arrayTwo ),
+			$differ->diffArrays($arrayOne, $arrayTwo),
 			$message
 		);
 	}
 
-	public function diffInputProvider() {
-		$argLists = array();
+	public function diffInputProvider(): array {
+		$argLists = [];
 
-		$argLists[] = array(
-			array(),
-			array(),
-			array(),
-			'The diff between empty arrays should be empty'
-		);
+		$argLists[] = [
+			[],
+			[],
+			[],
+			'The diff between empty arrays should be empty',
+		];
 
-		$argLists[] = array(
-			array( 1 ),
-			array( 1 ),
-			array(),
-			'The diff between identical arrays should be empty'
-		);
+		$argLists[] = [
+			[1],
+			[1],
+			[],
+			'The diff between identical arrays should be empty',
+		];
 
-		$argLists[] = array(
-			array( 1, 2 , 1 ),
-			array( 1, 1, 2 ),
-			array(),
-			'The diff between arrays with the same values but different orders should be empty'
-		);
+		$argLists[] = [
+			[1, 2, 1],
+			[1, 1, 2],
+			[],
+			'The diff between arrays with the same values but different orders should be empty',
+		];
 
-		$argLists[] = array(
-			array( 1, 1 ),
-			array( 1 ),
-			array( 1 ),
-			'The diff between an array with an element twice and an array that has it once should contain the element once'
-		);
+		$argLists[] = [
+			[1, 1],
+			[1],
+			[1],
+			'The diff between an array with an element twice and an array that has it once should contain the element once',
+		];
 
-		$argLists[] = array(
-			array( '0' ),
-			array( 0 ),
-			array( '0' ),
-			'Comparison should be strict'
-		);
+		$argLists[] = [
+			['0'],
+			[0],
+			['0'],
+			'Comparison should be strict',
+		];
 
-		$argLists[] = array(
-			array( false ),
-			array( null ),
-			array( false ),
-			'Comparison should be strict'
-		);
+		$argLists[] = [
+			[false],
+			[null],
+			[false],
+			'Comparison should be strict',
+		];
 
-		$argLists[] = array(
-			array( array( 1 ) ),
-			array( array( 2 ) ),
-			array( array( 1 ) ),
-			'Arrays are compared properly'
-		);
+		$argLists[] = [
+			[[1]],
+			[[2]],
+			[[1]],
+			'Arrays are compared properly',
+		];
 
-		$argLists[] = array(
-			array( array( 1 ) ),
-			array( array( 1 ) ),
-			array(),
-			'Arrays are compared properly'
-		);
+		$argLists[] = [
+			[[1]],
+			[[1]],
+			[],
+			'Arrays are compared properly',
+		];
 
-		$argLists[] = array(
-			array( new \stdClass() ),
-			array( new \stdClass() ),
-			array(),
-			'Objects are compared based on value, not identity'
-		);
+		$argLists[] = [
+			[new stdClass()],
+			[new stdClass()],
+			[],
+			'Objects are compared based on value, not identity',
+		];
 
-		$argLists[] = array(
-			array( (object)array( 'foo' => 'bar' ) ),
-			array( (object)array( 'foo' => 'baz' ) ),
-			array( (object)array( 'foo' => 'bar' ) ),
-			'Differences between objects are detected'
-		);
+		$argLists[] = [
+			[(object) ['foo' => 'bar']],
+			[(object) ['foo' => 'baz']],
+			[(object) ['foo' => 'bar']],
+			'Differences between objects are detected',
+		];
 
 		return $argLists;
 	}

--- a/tests/unit/Comparer/CallbackComparerTest.php
+++ b/tests/unit/Comparer/CallbackComparerTest.php
@@ -1,62 +1,64 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace Diff\Tests\Comparer;
 
 use Diff\Comparer\CallbackComparer;
 use Diff\Tests\DiffTestCase;
+use RuntimeException;
 
 /**
- * @covers \Diff\Comparer\CallbackComparer
+ * @covers  \Diff\Comparer\CallbackComparer
  *
- * @group Diff
- * @group Comparer
+ * @group   Diff
+ * @group   Comparer
  *
  * @license BSD-3-Clause
- * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author  Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class CallbackComparerTest extends DiffTestCase {
 
-	public function testWhenCallbackReturnsTrue_valuesAreEqual() {
-		$comparer = new CallbackComparer( function() {
+	public function testWhenCallbackReturnsTrue_valuesAreEqual(): void {
+		$comparer = new CallbackComparer(function () {
 			return true;
-		} );
+		});
 
-		$this->assertTrue( $comparer->valuesAreEqual( null, null ) );
+		$this->assertTrue($comparer->valuesAreEqual(null, null));
 	}
 
-	public function testWhenCallbackReturnsFalse_valuesAreNotEqual() {
-		$comparer = new CallbackComparer( function() {
+	public function testWhenCallbackReturnsFalse_valuesAreNotEqual(): void {
+		$comparer = new CallbackComparer(function () {
 			return false;
-		} );
+		});
 
-		$this->assertFalse( $comparer->valuesAreEqual( null, null ) );
+		$this->assertFalse($comparer->valuesAreEqual(null, null));
 	}
 
-	public function testWhenCallbackReturnsNonBoolean_exceptionIsThrown() {
-		$comparer = new CallbackComparer( function() {
+	public function testWhenCallbackReturnsNonBoolean_exceptionIsThrown(): void {
+		$comparer = new CallbackComparer(function () {
 			return null;
-		} );
+		});
 
-		$this->expectException( \RuntimeException::class );
-		$comparer->valuesAreEqual( null, null );
+		$this->expectException(RuntimeException::class);
+		$comparer->valuesAreEqual(null, null);
 	}
 
-	public function testCallbackIsGivenArguments() {
+	public function testCallbackIsGivenArguments(): void {
 		$firstArgument = null;
 		$secondArgument = null;
 
-		$comparer = new CallbackComparer( function( $a, $b ) use ( &$firstArgument, &$secondArgument ) {
+		$comparer = new CallbackComparer(function ($a, $b) use (&$firstArgument, &$secondArgument) {
 			$firstArgument = $a;
 			$secondArgument = $b;
+
 			return true;
-		} );
+		});
 
-		$comparer->valuesAreEqual( 42, 23 );
+		$comparer->valuesAreEqual(42, 23);
 
-		$this->assertSame( 42, $firstArgument );
-		$this->assertSame( 23, $secondArgument );
+		$this->assertSame(42, $firstArgument);
+		$this->assertSame(23, $secondArgument);
 	}
 
 }

--- a/tests/unit/Comparer/ComparableComparerTest.php
+++ b/tests/unit/Comparer/ComparableComparerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace Diff\Tests\Comparer;
 
@@ -9,74 +9,74 @@ use Diff\Tests\DiffTestCase;
 use Diff\Tests\Fixtures\StubComparable;
 
 /**
- * @covers \Diff\Comparer\ComparableComparer
+ * @covers  \Diff\Comparer\ComparableComparer
  *
- * @group Diff
- * @group Comparer
+ * @group   Diff
+ * @group   Comparer
  *
  * @license BSD-3-Clause
- * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author  Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class ComparableComparerTest extends DiffTestCase {
 
 	/**
 	 * @dataProvider equalProvider
 	 */
-	public function testEqualValuesAreEqual( $firstValue, $secondValue ) {
+	public function testEqualValuesAreEqual($firstValue, $secondValue): void {
 		$comparer = new ComparableComparer();
 
-		$this->assertTrue( $comparer->valuesAreEqual( $firstValue, $secondValue ) );
+		$this->assertTrue($comparer->valuesAreEqual($firstValue, $secondValue));
 	}
 
-	public function equalProvider() {
-		return array(
-			array(
-				new StubComparable( 100 ),
-				new StubComparable( 100 ),
-			),
-			array(
-				new StubComparable( 'abc' ),
-				new StubComparable( 'abc' ),
-			),
-			array(
-				new StubComparable( null ),
-				new StubComparable( null ),
-			),
-		);
+	public function equalProvider(): array {
+		return [
+			[
+				new StubComparable(100),
+				new StubComparable(100),
+			],
+			[
+				new StubComparable('abc'),
+				new StubComparable('abc'),
+			],
+			[
+				new StubComparable(null),
+				new StubComparable(null),
+			],
+		];
 	}
 
 	/**
 	 * @dataProvider unequalProvider
 	 */
-	public function testDifferentValuesAreNotEqual( $firstValue, $secondValue ) {
+	public function testDifferentValuesAreNotEqual($firstValue, $secondValue): void {
 		$comparer = new ComparableComparer();
 
-		$this->assertFalse( $comparer->valuesAreEqual( $firstValue, $secondValue ) );
+		$this->assertFalse($comparer->valuesAreEqual($firstValue, $secondValue));
 	}
 
-	public function unequalProvider() {
-		return array(
-			array(
+	public function unequalProvider(): array {
+		return [
+			[
 				null,
-				null
-			),
-			array(
-				new StubComparable( 1 ),
-				null
-			),
-			array(
-				new StubComparable( 1 ),
-				new StubComparable( 2 ),
-			),
-			array(
-				new StubComparable( 1 ),
-				new StubComparable( '1' ),
-			),
-			array(
-				new StubComparable( null ),
-				new StubComparable( false ),
-			),
-		);
+				null,
+			],
+			[
+				new StubComparable(1),
+				null,
+			],
+			[
+				new StubComparable(1),
+				new StubComparable(2),
+			],
+			[
+				new StubComparable(1),
+				new StubComparable('1'),
+			],
+			[
+				new StubComparable(null),
+				new StubComparable(false),
+			],
+		];
 	}
 
 }

--- a/tests/unit/Comparer/StrictComparerTest.php
+++ b/tests/unit/Comparer/StrictComparerTest.php
@@ -1,80 +1,81 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace Diff\Tests\Comparer;
 
 use Diff\Comparer\StrictComparer;
 use Diff\Tests\DiffTestCase;
+use stdClass;
 
 /**
- * @covers \Diff\Comparer\StrictComparer
+ * @covers  \Diff\Comparer\StrictComparer
  *
- * @group Diff
- * @group Comparer
+ * @group   Diff
+ * @group   Comparer
  *
  * @license BSD-3-Clause
- * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author  Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class StrictComparerTest extends DiffTestCase {
 
 	/**
 	 * @dataProvider equalProvider
 	 */
-	public function testEqualValuesAreEqual( $firstValue, $secondValue ) {
+	public function testEqualValuesAreEqual($firstValue, $secondValue): void {
 		$comparer = new StrictComparer();
 
-		$this->assertTrue( $comparer->valuesAreEqual( $firstValue, $secondValue ) );
+		$this->assertTrue($comparer->valuesAreEqual($firstValue, $secondValue));
 	}
 
-	public function equalProvider() {
-		return array(
-			array( 1, 1 ),
-			array( '', '' ),
-			array( '1', '1' ),
-			array( 'foo bar ', 'foo bar ' ),
-			array( 4.2, 4.2 ),
-			array( null, null ),
-			array( false, false ),
-			array( true, true ),
-			array( array(), array() ),
-			array( array( 1 ), array( 1 ) ),
-			array( array( 1, 2, 'a' ), array( 1, 2, 'a' ) ),
-			array( array( 'a' => 1, 'b' => 2, null ), array( 'a' => 1, 'b' => 2, null ) ),
-		);
+	public function equalProvider(): array {
+		return [
+			[1, 1],
+			['', ''],
+			['1', '1'],
+			['foo bar ', 'foo bar '],
+			[4.2, 4.2],
+			[null, null],
+			[false, false],
+			[true, true],
+			[[], []],
+			[[1], [1]],
+			[[1, 2, 'a'], [1, 2, 'a']],
+			[['a' => 1, 'b' => 2, null], ['a' => 1, 'b' => 2, null]],
+		];
 	}
 
 	/**
 	 * @dataProvider unequalProvider
 	 */
-	public function testDifferentValuesAreNotEqual( $firstValue, $secondValue ) {
+	public function testDifferentValuesAreNotEqual($firstValue, $secondValue): void {
 		$comparer = new StrictComparer();
 
-		$this->assertFalse( $comparer->valuesAreEqual( $firstValue, $secondValue ) );
+		$this->assertFalse($comparer->valuesAreEqual($firstValue, $secondValue));
 	}
 
-	public function unequalProvider() {
-		return array(
-			array( 1, 2 ),
-			array( '', '0' ),
-			array( '', ' ' ),
-			array( '', 0 ),
-			array( '', false ),
-			array( null, false ),
-			array( null, 0 ),
-			array( '1', '01' ),
-			array( 'foo bar', 'foo bar ' ),
-			array( 4, 4.0 ),
-			array( 4.2, 4.3 ),
-			array( false, true ),
-			array( true, '1' ),
-			array( array(), array( 1 ) ),
-			array( array( 1 ), array( 2 ) ),
-			array( array( 1, 2, 'b' ), array( 1, 2, 'c' ) ),
-			array( array( 'a' => 1, 'b' => 2 ), array( 'a' => 1, 'b' => 2, null ) ),
-			array( new \stdClass(), new \stdClass() ),
-			array( (object)array( 'a' => 1, 'b' => 2, null ), (object)array( 'a' => 1, 'b' => 3, null ) ),
-		);
+	public function unequalProvider(): array {
+		return [
+			[1, 2],
+			['', '0'],
+			['', ' '],
+			['', 0],
+			['', false],
+			[null, false],
+			[null, 0],
+			['1', '01'],
+			['foo bar', 'foo bar '],
+			[4, 4.0],
+			[4.2, 4.3],
+			[false, true],
+			[true, '1'],
+			[[], [1]],
+			[[1], [2]],
+			[[1, 2, 'b'], [1, 2, 'c']],
+			[['a' => 1, 'b' => 2], ['a' => 1, 'b' => 2, null]],
+			[new stdClass(), new stdClass()],
+			[(object) ['a' => 1, 'b' => 2, null], (object) ['a' => 1, 'b' => 3, null]],
+		];
 	}
 
 }

--- a/tests/unit/DiffOp/Diff/DiffAsOpTest.php
+++ b/tests/unit/DiffOp/Diff/DiffAsOpTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace Diff\Tests\DiffOp\Diff;
 
@@ -8,51 +8,52 @@ use Diff\DiffOp\Diff\Diff;
 use Diff\DiffOp\DiffOpAdd;
 use Diff\DiffOp\DiffOpRemove;
 use Diff\Tests\DiffOp\DiffOpTest;
+use stdClass;
 
 /**
- * @covers \Diff\DiffOp\Diff\Diff
+ * @covers  \Diff\DiffOp\Diff\Diff
  *
- * @group Diff
- * @group DiffOp
+ * @group   Diff
+ * @group   DiffOp
  *
  * @license BSD-3-Clause
- * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author  Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class DiffAsOpTest extends DiffOpTest {
 
 	/**
-	 * @see DiffOpTest::getClass
-	 *
+	 * @return string
 	 * @since 0.5
 	 *
-	 * @return string
+	 * @see   DiffOpTest::getClass
+	 *
 	 */
-	public function getClass() {
+	public function getClass(): string {
 		return '\Diff\DiffOp\Diff\Diff';
 	}
 
 	/**
-	 * @see DiffOpTest::constructorProvider
+	 * @see   DiffOpTest::constructorProvider
 	 *
 	 * @since 0.5
 	 */
-	public function constructorProvider() {
-		$argLists = array(
-			array( true, array() ),
-			array( true, array( new DiffOpAdd( 42 ) ) ),
-			array( true, array( new DiffOpRemove( new DiffOpRemove( 'spam' ) ) ) ),
-			array( true, array( new Diff( array( new DiffOpRemove( new DiffOpRemove( 'spam' ) ) ) ) ) ),
-			array( true, array( new DiffOpAdd( 42 ), new DiffOpAdd( 42 ) ) ),
-			array( true, array( 'a' => new DiffOpAdd( 42 ), 'b' => new DiffOpAdd( 42 ) ) ),
-			array( true, array( new DiffOpAdd( 42 ), 'foo bar baz' => new DiffOpAdd( 42 ) ) ),
-			array( true, array( 42 => new DiffOpRemove( 42 ), '9001' => new DiffOpAdd( 42 ) ) ),
-			array( true, array( 42 => new DiffOpRemove( new \stdClass() ), '9001' => new DiffOpAdd( new \stdClass() ) ) ),
-		);
+	public function constructorProvider(): array {
+		$argLists = [
+			[true, []],
+			[true, [new DiffOpAdd(42)]],
+			[true, [new DiffOpRemove(new DiffOpRemove('spam'))]],
+			[true, [new Diff([new DiffOpRemove(new DiffOpRemove('spam'))])]],
+			[true, [new DiffOpAdd(42), new DiffOpAdd(42)]],
+			[true, ['a' => new DiffOpAdd(42), 'b' => new DiffOpAdd(42)]],
+			[true, [new DiffOpAdd(42), 'foo bar baz' => new DiffOpAdd(42)]],
+			[true, [42 => new DiffOpRemove(42), '9001' => new DiffOpAdd(42)]],
+			[true, [42 => new DiffOpRemove(new stdClass()), '9001' => new DiffOpAdd(new stdClass())]],
+		];
 
 		$allArgLists = $argLists;
 
-		foreach ( $argLists as $argList ) {
-			foreach ( array( true, false, null ) as $isAssoc ) {
+		foreach ($argLists as $argList) {
+			foreach ([true, false, null] as $isAssoc) {
 				$argList[] = $isAssoc;
 				$allArgLists[] = $argList;
 			}
@@ -64,16 +65,16 @@ class DiffAsOpTest extends DiffOpTest {
 	/**
 	 * @dataProvider instanceProvider
 	 */
-	public function testToArrayMore( Diff $diffOp ) {
+	public function testToArrayMore(Diff $diffOp): void {
 		$array = $diffOp->toArray();
 
-		$this->assertArrayHasKey( 'operations', $array );
-		$this->assertIsArray( $array['operations'] );
+		$this->assertArrayHasKey('operations', $array);
+		$this->assertIsArray($array['operations']);
 
-		$this->assertArrayHasKey( 'isassoc', $array );
+		$this->assertArrayHasKey('isassoc', $array);
 
 		$this->assertTrue(
-			is_bool( $array['isassoc'] ) || $array['isassoc'] === null,
+			is_bool($array['isassoc']) || $array['isassoc'] === null,
 			'The isassoc element needs to be a boolean or null'
 		);
 	}

--- a/tests/unit/DiffOp/Diff/DiffTest.php
+++ b/tests/unit/DiffOp/Diff/DiffTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace Diff\Tests\DiffOp\Diff;
 
@@ -11,334 +11,349 @@ use Diff\DiffOp\DiffOpAdd;
 use Diff\DiffOp\DiffOpChange;
 use Diff\DiffOp\DiffOpRemove;
 use Diff\Tests\DiffTestCase;
+use Generator;
 use stdClass;
 
 /**
- * @covers \Diff\DiffOp\Diff\Diff
+ * @covers  \Diff\DiffOp\Diff\Diff
  *
- * @group Diff
- * @group DiffOp
+ * @group   Diff
+ * @group   DiffOp
  *
  * @license BSD-3-Clause
- * @author Jeroen De Dauw < jeroendedauw@gmail.com >
- * @author Thiemo Kreuz
+ * @author  Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author  Thiemo Kreuz
  */
 class DiffTest extends DiffTestCase {
-
-	public function elementInstancesProvider() {
-		return array(
-			array( array(
-			) ),
-			array( array(
-				new DiffOpAdd( 'ohi' )
-			) ),
-			array( array(
-				new DiffOpRemove( 'ohi' )
-			) ),
-			array( array(
-				new DiffOpAdd( 'ohi' ),
-				new DiffOpRemove( 'there' )
-			) ),
-			array( array(
-			) ),
-			array( array(
-				new DiffOpAdd( 'ohi' ),
-				new DiffOpRemove( 'there' ),
-				new DiffOpChange( 'ohi', 'there' )
-			) ),
-			array( array(
-				'1' => new DiffOpAdd( 'ohi' ),
-				'33' => new DiffOpRemove( 'there' ),
-				'7' => new DiffOpChange( 'ohi', 'there' )
-			) ),
-		);
-	}
 
 	/**
 	 * @dataProvider elementInstancesProvider
 	 * @param DiffOp[] $operations
 	 */
-	public function testGetAdditions( array $operations ) {
-		$diff = new Diff( $operations, true );
+	public function testGetAdditions(array $operations): void {
+		$diff = new Diff($operations, true);
 
-		$additions = array();
+		$additions = [];
 
-		foreach ( $operations as $operation ) {
-			if ( $operation->getType() == 'add' ) {
+		foreach ($operations as $operation) {
+			if ($operation->getType() == 'add') {
 				$additions[] = $operation;
 			}
 		}
 
-		$this->assertArrayEquals( $additions, $diff->getAdditions() );
+		$this->assertArrayEquals($additions, $diff->getAdditions());
 	}
 
 	/**
 	 * @dataProvider elementInstancesProvider
 	 * @param DiffOp[] $operations
 	 */
-	public function testGetRemovals( array $operations ) {
-		$diff = new Diff( $operations, true );
+	public function testGetRemovals(array $operations): void {
+		$diff = new Diff($operations, true);
 
-		$removals = array();
+		$removals = [];
 
-		foreach ( $operations as $operation ) {
-			if ( $operation->getType() == 'remove' ) {
+		foreach ($operations as $operation) {
+			if ($operation->getType() == 'remove') {
 				$removals[] = $operation;
 			}
 		}
 
-		$this->assertArrayEquals( $removals, $diff->getRemovals() );
+		$this->assertArrayEquals($removals, $diff->getRemovals());
 	}
 
-	public function testGetType() {
+	public function testGetType(): void {
 		$diff = new Diff();
-		$this->assertIsString( $diff->getType() );
+		$this->assertIsString($diff->getType());
 	}
 
-	public function testPreSetElement() {
-		$this->expectException( 'Exception' );
+	public function testPreSetElement(): void {
+		$this->expectException('Exception');
 
-		$diff = new Diff( array(), false );
-		$diff[] = new DiffOpChange( 0, 1 );
+		$diff = new Diff([], false);
+		$diff[] = new DiffOpChange(0, 1);
 	}
 
 	/**
 	 * @dataProvider elementInstancesProvider
 	 * @param DiffOp[] $operations
 	 */
-	public function testAddOperations( array $operations ) {
+	public function testAddOperations(array $operations): void {
 		$diff = new Diff();
 
-		$diff->addOperations( $operations );
+		$diff->addOperations($operations);
 
-		$this->assertArrayEquals( $operations, $diff->getOperations() );
+		$this->assertArrayEquals($operations, $diff->getOperations());
 	}
 
 	/**
 	 * @dataProvider elementInstancesProvider
 	 * @param DiffOp[] $operations
 	 */
-	public function testStuff( array $operations ) {
-		$diff = new Diff( $operations );
+	public function testStuff(array $operations): void {
+		$diff = new Diff($operations);
 
-		$this->assertInstanceOf( 'Diff\DiffOp\Diff\Diff', $diff );
-		$this->assertInstanceOf( 'ArrayObject', $diff );
+		$this->assertInstanceOf('Diff\DiffOp\Diff\Diff', $diff);
+		$this->assertInstanceOf('ArrayObject', $diff);
 
-		$types = array();
+		$types = [];
 
-		$this->assertContainsOnlyInstancesOf( 'Diff\DiffOp\DiffOp', $diff );
+		$this->assertContainsOnlyInstancesOf('Diff\DiffOp\DiffOp', $diff);
 
 		/**
 		 * @var DiffOp $operation
 		 */
-		foreach ( $diff as $operation ) {
-			if ( !in_array( $operation->getType(), $types ) ) {
+		foreach ($diff as $operation) {
+			if (!in_array($operation->getType(), $types)) {
 				$types[] = $operation->getType();
 			}
 		}
 
 		$count = 0;
 
-		foreach ( $types as $type ) {
-			$count += count( $diff->getTypeOperations( $type ) );
+		foreach ($types as $type) {
+			$count += count($diff->getTypeOperations($type));
 		}
 
-		$this->assertEquals( $count, $diff->count() );
+		$this->assertEquals($count, $diff->count());
 	}
 
-	public function instanceProvider() {
-		foreach ( $this->elementInstancesProvider() as $args ) {
-			yield [ new Diff( $args[0] ) ];
+	public function instanceProvider(): Generator {
+		foreach ($this->elementInstancesProvider() as $args) {
+			yield [new Diff($args[0])];
 		}
+	}
+
+	public function elementInstancesProvider(): array {
+		return [
+			[
+				[
+				],
+			],
+			[
+				[
+					new DiffOpAdd('ohi'),
+				],
+			],
+			[
+				[
+					new DiffOpRemove('ohi'),
+				],
+			],
+			[
+				[
+					new DiffOpAdd('ohi'),
+					new DiffOpRemove('there'),
+				],
+			],
+			[
+				[
+				],
+			],
+			[
+				[
+					new DiffOpAdd('ohi'),
+					new DiffOpRemove('there'),
+					new DiffOpChange('ohi', 'there'),
+				],
+			],
+			[
+				[
+					'1' => new DiffOpAdd('ohi'),
+					'33' => new DiffOpRemove('there'),
+					'7' => new DiffOpChange('ohi', 'there'),
+				],
+			],
+		];
 	}
 
 	/**
 	 * @dataProvider instanceProvider
 	 */
-	public function testGetOperations( Diff $diff ) {
+	public function testGetOperations(Diff $diff): void {
 		$ops = $diff->getOperations();
 
-		$this->assertIsArray( $ops );
-		$this->assertContainsOnlyInstancesOf( 'Diff\DiffOp\DiffOp', $ops );
-		$this->assertArrayEquals( $ops, $diff->getOperations() );
+		$this->assertIsArray($ops);
+		$this->assertContainsOnlyInstancesOf('Diff\DiffOp\DiffOp', $ops);
+		$this->assertArrayEquals($ops, $diff->getOperations());
 	}
 
-	public function testRemoveEmptyOperations() {
-		$diff = new Diff( array() );
+	public function testRemoveEmptyOperations(): void {
+		$diff = new Diff([]);
 
-		$diff['foo'] = new DiffOpAdd( 1 );
-		$diff['bar'] = new Diff( array( new DiffOpAdd( 1 ) ), true );
-		$diff['baz'] = new Diff( array( new DiffOpAdd( 1 ) ), false );
-		$diff['bah'] = new Diff( array(), false );
-		$diff['spam'] = new Diff( array(), true );
+		$diff['foo'] = new DiffOpAdd(1);
+		$diff['bar'] = new Diff([new DiffOpAdd(1)], true);
+		$diff['baz'] = new Diff([new DiffOpAdd(1)], false);
+		$diff['bah'] = new Diff([], false);
+		$diff['spam'] = new Diff([], true);
 
 		$diff->removeEmptyOperations();
 
-		$this->assertTrue( $diff->offsetExists( 'foo' ) );
-		$this->assertTrue( $diff->offsetExists( 'bar' ) );
-		$this->assertTrue( $diff->offsetExists( 'baz' ) );
-		$this->assertFalse( $diff->offsetExists( 'bah' ) );
-		$this->assertFalse( $diff->offsetExists( 'spam' ) );
+		$this->assertTrue($diff->offsetExists('foo'));
+		$this->assertTrue($diff->offsetExists('bar'));
+		$this->assertTrue($diff->offsetExists('baz'));
+		$this->assertFalse($diff->offsetExists('bah'));
+		$this->assertFalse($diff->offsetExists('spam'));
 	}
 
-	public function looksAssociativeProvider() {
-		return array(
-			array( new Diff(), false ),
-			array( new Diff( array(), false ), false ),
-			array( new Diff( array(), true ), true ),
-			array( new Diff( array( new DiffOpAdd( '' ) ) ), false ),
-			array( new Diff( array( new DiffOpRemove( '' ) ) ), false ),
-			array( new Diff( array( new DiffOpRemove( '' ), new DiffOpAdd( '' ) ) ), false ),
-			array( new Diff( array( new DiffOpRemove( '' ) ), true ), true ),
-			array( new Diff( array( 'onoez' => new DiffOpChange( '', 'spam' ) ) ), true ),
-			array( new Diff( array( new Diff() ) ), true ),
-		);
+	public function looksAssociativeProvider(): array {
+		return [
+			[new Diff(), false],
+			[new Diff([], false), false],
+			[new Diff([], true), true],
+			[new Diff([new DiffOpAdd('')]), false],
+			[new Diff([new DiffOpRemove('')]), false],
+			[new Diff([new DiffOpRemove(''), new DiffOpAdd('')]), false],
+			[new Diff([new DiffOpRemove('')], true), true],
+			[new Diff(['onoez' => new DiffOpChange('', 'spam')]), true],
+			[new Diff([new Diff()]), true],
+		];
 	}
 
 	/**
 	 * @dataProvider looksAssociativeProvider
 	 */
-	public function testLooksAssociative( Diff $diff, $looksAssoc ) {
-		$this->assertEquals( $looksAssoc, $diff->looksAssociative() );
+	public function testLooksAssociative(Diff $diff, $looksAssoc): void {
+		$this->assertEquals($looksAssoc, $diff->looksAssociative());
 
-		if ( !$diff->looksAssociative() ) {
-			$this->assertFalse( $diff->hasAssociativeOperations() );
+		if (!$diff->looksAssociative()) {
+			$this->assertFalse($diff->hasAssociativeOperations());
 		}
 	}
 
-	public function isAssociativeProvider() {
-		return array(
-			array( new Diff(), null ),
-			array( new Diff( array(), false ), false ),
-			array( new Diff( array(), true ), true ),
-			array( new Diff( array( new DiffOpAdd( '' ) ) ), null ),
-			array( new Diff( array( new DiffOpRemove( '' ) ), false ), false ),
-			array( new Diff( array( new DiffOpRemove( '' ), new DiffOpAdd( '' ) ) ), null ),
-			array( new Diff( array( new DiffOpRemove( '' ) ), true ), true ),
-			array( new Diff( array( 'onoez' => new DiffOpChange( '', 'spam' ) ) ), null ),
-			array( new Diff( array( new Diff() ) ), null ),
-		);
+	public function isAssociativeProvider(): array {
+		return [
+			[new Diff(), null],
+			[new Diff([], false), false],
+			[new Diff([], true), true],
+			[new Diff([new DiffOpAdd('')]), null],
+			[new Diff([new DiffOpRemove('')], false), false],
+			[new Diff([new DiffOpRemove(''), new DiffOpAdd('')]), null],
+			[new Diff([new DiffOpRemove('')], true), true],
+			[new Diff(['onoez' => new DiffOpChange('', 'spam')]), null],
+			[new Diff([new Diff()]), null],
+		];
 	}
 
 	/**
 	 * @dataProvider isAssociativeProvider
 	 */
-	public function testIsAssociative( Diff $diff, $isAssoc ) {
-		$this->assertEquals( $isAssoc, $diff->isAssociative() );
+	public function testIsAssociative(Diff $diff, $isAssoc): void {
+		$this->assertEquals($isAssoc, $diff->isAssociative());
 	}
 
-	public function hasAssociativeOperationsProvider() {
-		return array(
-			array( new Diff(), false ),
-			array( new Diff( array(), false ), false ),
-			array( new Diff( array(), true ), false ),
-			array( new Diff( array( new DiffOpAdd( '' ) ) ), false ),
-			array( new Diff( array( new DiffOpRemove( '' ) ), false ), false ),
-			array( new Diff( array( new DiffOpRemove( '' ), new DiffOpAdd( '' ) ), true ), false ),
-			array( new Diff( array( new DiffOpRemove( '' ) ), true ), false ),
-			array( new Diff( array( 'onoez' => new DiffOpChange( '', 'spam' ) ) ), true ),
-			array( new Diff( array( new Diff() ) ), true ),
-		);
+	public function hasAssociativeOperationsProvider(): array {
+		return [
+			[new Diff(), false],
+			[new Diff([], false), false],
+			[new Diff([], true), false],
+			[new Diff([new DiffOpAdd('')]), false],
+			[new Diff([new DiffOpRemove('')], false), false],
+			[new Diff([new DiffOpRemove(''), new DiffOpAdd('')], true), false],
+			[new Diff([new DiffOpRemove('')], true), false],
+			[new Diff(['onoez' => new DiffOpChange('', 'spam')]), true],
+			[new Diff([new Diff()]), true],
+		];
 	}
 
 	/**
 	 * @dataProvider hasAssociativeOperationsProvider
 	 */
-	public function testHasAssociativeOperations( Diff $diff, $hasAssocOps ) {
-		$this->assertEquals( $hasAssocOps, $diff->hasAssociativeOperations() );
+	public function testHasAssociativeOperations(Diff $diff, $hasAssocOps): void {
+		$this->assertEquals($hasAssocOps, $diff->hasAssociativeOperations());
 	}
 
 	/**
 	 * @dataProvider elementInstancesProvider
 	 *
-	 * @since 0.6
-	 *
 	 * @param DiffOp[] $elements
+	 * @since        0.6
+	 *
 	 */
-	public function testConstructor( array $elements ) {
-		$arrayObject = new Diff( $elements );
+	public function testConstructor(array $elements): void {
+		$arrayObject = new Diff($elements);
 
-		$this->assertEquals( count( $elements ), $arrayObject->count() );
+		$this->assertEquals(count($elements), $arrayObject->count());
 	}
 
 	/**
 	 * @dataProvider elementInstancesProvider
 	 *
-	 * @since 0.6
-	 *
 	 * @param DiffOp[] $elements
+	 * @since        0.6
+	 *
 	 */
-	public function testIsEmpty( array $elements ) {
-		$arrayObject = new Diff( $elements );
+	public function testIsEmpty(array $elements): void {
+		$arrayObject = new Diff($elements);
 
-		$this->assertEquals( $elements === array(), $arrayObject->isEmpty() );
+		$this->assertEquals($elements === [], $arrayObject->isEmpty());
 	}
 
 	/**
 	 * @dataProvider instanceProvider
 	 *
-	 * @since 0.6
-	 *
 	 * @param Diff $list
+	 * @since        0.6
+	 *
 	 */
-	public function testUnset( Diff $list ) {
-		if ( $list->isEmpty() ) {
-			$this->assertTrue( true ); // We cannot test unset if there are no elements
+	public function testUnset(Diff $list): void {
+		if ($list->isEmpty()) {
+			$this->assertTrue(true); // We cannot test unset if there are no elements
 		} else {
 			$offset = $list->getIterator()->key();
 			$count = $list->count();
-			$list->offsetUnset( $offset );
-			$this->assertEquals( $count - 1, $list->count() );
+			$list->offsetUnset($offset);
+			$this->assertEquals($count - 1, $list->count());
 		}
 
-		if ( !$list->isEmpty() ) {
+		if (!$list->isEmpty()) {
 			$offset = $list->getIterator()->key();
 			$count = $list->count();
-			unset( $list[$offset] );
-			$this->assertEquals( $count - 1, $list->count() );
+			unset($list[$offset]);
+			$this->assertEquals($count - 1, $list->count());
 		}
 	}
 
 	/**
 	 * @dataProvider elementInstancesProvider
 	 *
-	 * @since 0.6
-	 *
 	 * @param DiffOp[] $elements
+	 * @since        0.6
+	 *
 	 */
-	public function testAppend( array $elements ) {
+	public function testAppend(array $elements): void {
 		$list = new Diff();
 
-		$listSize = count( $elements );
+		$listSize = count($elements);
 
-		foreach ( $elements as $element ) {
-			$list->append( $element );
+		foreach ($elements as $element) {
+			$list->append($element);
 		}
 
-		$this->assertEquals( $listSize, $list->count() );
+		$this->assertEquals($listSize, $list->count());
 
 		$list = new Diff();
 
-		foreach ( $elements as $element ) {
+		foreach ($elements as $element) {
 			$list[] = $element;
 		}
 
-		$this->assertEquals( $listSize, $list->count() );
+		$this->assertEquals($listSize, $list->count());
 
-		$this->checkTypeChecks( function ( Diff $list, $element ) {
-			$list->append( $element );
-		} );
+		$this->checkTypeChecks(function (Diff $list, $element) {
+			$list->append($element);
+		});
 	}
 
 	/**
 	 * @param Closure $function
 	 */
-	private function checkTypeChecks( Closure $function ) {
+	private function checkTypeChecks(Closure $function): void {
 		$excption = null;
 		$list = new Diff();
 
-		foreach ( array( 42, 'foo', array(), new stdClass(), 4.2 ) as $element ) {
-			$this->assertInvalidArgument( $function, $list, $element );
+		foreach ([42, 'foo', [], new stdClass(), 4.2] as $element) {
+			$this->assertInvalidArgument($function, $list, $element);
 		}
 	}
 
@@ -348,264 +363,279 @@ class DiffTest extends DiffTestCase {
 	 *
 	 * @param Closure $function
 	 */
-	private function assertInvalidArgument( Closure $function ) {
-		$this->expectException( 'InvalidArgumentException' );
+	private function assertInvalidArgument(Closure $function): void {
+		$this->expectException('InvalidArgumentException');
 
 		$arguments = func_get_args();
-		array_shift( $arguments );
+		array_shift($arguments);
 
-		call_user_func_array( $function, $arguments );
+		call_user_func_array($function, $arguments);
 	}
 
-	public function testGetAddedValues() {
-		$diff = new Diff( array(
-			new DiffOpAdd( 0 ),
-			new DiffOpRemove( 1 ),
-			new DiffOpAdd( 2 ),
-			new DiffOpRemove( 3 ),
-			new DiffOpAdd( 4 ),
-			new DiffOpChange( 7, 5 ),
-			new Diff( array( new DiffOpAdd( 9 ) ) ),
-		) );
+	public function testGetAddedValues(): void {
+		$diff = new Diff(
+			[
+				new DiffOpAdd(0),
+				new DiffOpRemove(1),
+				new DiffOpAdd(2),
+				new DiffOpRemove(3),
+				new DiffOpAdd(4),
+				new DiffOpChange(7, 5),
+				new Diff([new DiffOpAdd(9)]),
+			]
+		);
 
 		$addedValues = $diff->getAddedValues();
 
-		$this->assertIsArray( $addedValues );
+		$this->assertIsArray($addedValues);
 
-		$this->assertArrayEquals( array( 0, 2, 4 ), $addedValues );
+		$this->assertArrayEquals([0, 2, 4], $addedValues);
 
 		$diff = new Diff();
-		$this->assertArrayEquals( array(), $diff->getAddedValues() );
+		$this->assertArrayEquals([], $diff->getAddedValues());
 	}
 
-	public function testGetRemovedValues() {
-		$diff = new Diff( array(
-			new DiffOpAdd( 0 ),
-			new DiffOpRemove( 1 ),
-			new DiffOpAdd( 2 ),
-			new DiffOpRemove( 3 ),
-			new DiffOpAdd( 4 ),
-			new DiffOpChange( 6, 4 ),
-			new Diff( array( new DiffOPRemove( 8 ) ) ),
-		) );
+	public function testGetRemovedValues(): void {
+		$diff = new Diff(
+			[
+				new DiffOpAdd(0),
+				new DiffOpRemove(1),
+				new DiffOpAdd(2),
+				new DiffOpRemove(3),
+				new DiffOpAdd(4),
+				new DiffOpChange(6, 4),
+				new Diff([new DiffOPRemove(8)]),
+			]
+		);
 
 		$removedValues = $diff->getRemovedValues();
 
-		$this->assertIsArray( $removedValues );
+		$this->assertIsArray($removedValues);
 
-		$this->assertArrayEquals( array( 1, 3 ), $removedValues );
+		$this->assertArrayEquals([1, 3], $removedValues);
 
 		$diff = new Diff();
-		$this->assertArrayEquals( array(), $diff->getRemovedValues() );
+		$this->assertArrayEquals([], $diff->getRemovedValues());
 	}
 
 	/**
 	 * @dataProvider elementInstancesProvider
 	 *
-	 * @since 0.6
-	 *
 	 * @param DiffOp[] $elements
+	 * @since        0.6
+	 *
 	 */
-	public function testOffsetSet( array $elements ) {
-		if ( $elements === array() ) {
-			$this->assertTrue( true );
+	public function testOffsetSet(array $elements): void {
+		if ($elements === []) {
+			$this->assertTrue(true);
+
 			return;
 		}
 
 		$list = new Diff();
 
-		$element = reset( $elements );
-		$list->offsetSet( 42, $element );
-		$this->assertEquals( $element, $list->offsetGet( 42 ) );
+		$element = reset($elements);
+		$list->offsetSet(42, $element);
+		$this->assertEquals($element, $list->offsetGet(42));
 
 		$list = new Diff();
 
-		$element = reset( $elements );
+		$element = reset($elements);
 		$list['oHai'] = $element;
-		$this->assertEquals( $element, $list['oHai'] );
+		$this->assertEquals($element, $list['oHai']);
 
 		$list = new Diff();
 
-		$element = reset( $elements );
-		$list->offsetSet( 9001, $element );
-		$this->assertEquals( $element, $list[9001] );
+		$element = reset($elements);
+		$list->offsetSet(9001, $element);
+		$this->assertEquals($element, $list[9001]);
 
 		$list = new Diff();
 
-		$element = reset( $elements );
-		$list->offsetSet( null, $element );
-		$this->assertEquals( $element, $list[0] );
+		$element = reset($elements);
+		$list->offsetSet(null, $element);
+		$this->assertEquals($element, $list[0]);
 
 		$list = new Diff();
 		$offset = 0;
 
-		foreach ( $elements as $element ) {
-			$list->offsetSet( null, $element );
-			$this->assertEquals( $element, $list[$offset++] );
+		foreach ($elements as $element) {
+			$list->offsetSet(null, $element);
+			$this->assertEquals($element, $list[$offset++]);
 		}
 
-		$this->assertEquals( count( $elements ), $list->count() );
+		$this->assertEquals(count($elements), $list->count());
 
-		$this->checkTypeChecks( function ( Diff $list, $element ) {
-			$list->offsetSet( mt_rand(), $element );
-		} );
+		$this->checkTypeChecks(function (Diff $list, $element) {
+			$list->offsetSet(mt_rand(), $element);
+		});
 	}
 
 	/**
 	 * @dataProvider instanceProvider
 	 *
-	 * @since 0.6
-	 *
 	 * @param Diff $list
+	 * @since        0.6
+	 *
 	 */
-	public function testSerialization( Diff $list ) {
-		$serialization = serialize( $list );
-		$copy = unserialize( $serialization );
+	public function testSerialization(Diff $list): void {
+		$serialization = serialize($list);
+		$copy = unserialize($serialization);
 
-		$this->assertSame( $serialization, serialize( $copy ) );
-		$this->assertSame( $list->count(), $copy->count() );
+		$this->assertSame($serialization, serialize($copy));
+		$this->assertSame($list->count(), $copy->count());
 
 		$list = $list->getArrayCopy();
 		$copy = $copy->getArrayCopy();
 
-		$this->assertArrayEquals( $list, $copy, true, true );
+		$this->assertArrayEquals($list, $copy, true, true);
 	}
 
 	/**
 	 * @dataProvider instanceProvider
 	 *
-	 * @since 0.6
-	 *
 	 * @param Diff $list
+	 * @since        0.6
+	 *
 	 */
-	public function testAddInvalidDiffOp( Diff $list ) {
-		$invalidDiffOp = $this->createMock( 'Diff\DiffOp\DiffOp' );
+	public function testAddInvalidDiffOp(Diff $list): void {
+		$invalidDiffOp = $this->createMock('Diff\DiffOp\DiffOp');
 
-		$invalidDiffOp->expects( $this->atLeastOnce() )
-			->method( 'getType' )
-			->will( $this->returnValue( '~=[,,_,,]:3' ) );
+		$invalidDiffOp->expects($this->atLeastOnce())
+			->method('getType')
+			->will($this->returnValue('~=[,,_,,]:3'));
 
-		$this->expectException( 'Exception' );
+		$this->expectException('Exception');
 
-		$list->append( $invalidDiffOp );
+		$list->append($invalidDiffOp);
 	}
 
 	/**
 	 * @dataProvider invalidIsAssociativeProvider
 	 */
-	public function testConstructWithInvalidIsAssociative( $isAssociative ) {
-		$this->expectException( 'InvalidArgumentException' );
-		new Diff( array(), $isAssociative );
+	public function testConstructWithInvalidIsAssociative($isAssociative): void {
+		$this->expectException('InvalidArgumentException');
+		new Diff([], $isAssociative);
 	}
 
 	public function invalidIsAssociativeProvider() {
-		return array(
-			array( 1 ),
-			array( '1' ),
-			array( 'null' ),
-			array( 0 ),
-			array( array() ),
-			array( 'foobar' ),
-		);
+		return [
+			[1],
+			['1'],
+			['null'],
+			[0],
+			[[]],
+			['foobar'],
+		];
 	}
 
 	/**
 	 * @dataProvider invalidDiffOpsProvider
 	 */
-	public function testConstructorWithInvalidDiffOps( array $diffOps ) {
-		$this->expectException( 'InvalidArgumentException' );
-		new Diff( $diffOps );
+	public function testConstructorWithInvalidDiffOps(array $diffOps): void {
+		$this->expectException('InvalidArgumentException');
+		new Diff($diffOps);
 	}
 
-	public function invalidDiffOpsProvider() {
-		return array(
-			array( array(
-				'foo',
-			) ),
-			array( array(
-				null,
-			) ),
-			array( array(
-				false,
-				true,
-				array(),
-			) ),
-			array( array(
-				new DiffOpAdd( 42 ),
-				'in your list',
-				new DiffOpAdd( 9001 ),
-			) )
-		);
+	public function invalidDiffOpsProvider(): array {
+		return [
+			[
+				[
+					'foo',
+				],
+			],
+			[
+				[
+					null,
+				],
+			],
+			[
+				[
+					false,
+					true,
+					[],
+				],
+			],
+			[
+				[
+					new DiffOpAdd(42),
+					'in your list',
+					new DiffOpAdd(9001),
+				],
+			],
+		];
 	}
 
 	/**
 	 * @dataProvider equalsProvider
 	 */
-	public function testEquals( Diff $diff, Diff $target ) {
-		$this->assertTrue( $diff->equals( $target ) );
-		$this->assertTrue( $target->equals( $diff ) );
+	public function testEquals(Diff $diff, Diff $target): void {
+		$this->assertTrue($diff->equals($target));
+		$this->assertTrue($target->equals($diff));
 	}
 
-	public function equalsProvider() {
+	public function equalsProvider(): array {
 		$empty = new Diff();
 
-		return array(
+		return [
 			// Identity
-			array( $empty, $empty ),
+			[$empty, $empty],
 
 			// Empty diffs
-			array( $empty, new Diff() ),
-			array( $empty, new Diff( array(), null ) ),
+			[$empty, new Diff()],
+			[$empty, new Diff([], null)],
 
 			// Simple diffs
-			array( new Diff( array( new DiffOpAdd( 1 ) ) ), new Diff( array( new DiffOpAdd( 1 ) ) ) ),
-			array( new Diff( array( new DiffOpAdd( 1 ) ) ), new Diff( array( new DiffOpAdd( '1' ) ) ) ),
-		);
+			[new Diff([new DiffOpAdd(1)]), new Diff([new DiffOpAdd(1)])],
+			[new Diff([new DiffOpAdd(1)]), new Diff([new DiffOpAdd('1')])],
+		];
 	}
 
 	/**
 	 * @dataProvider notEqualsProvider
 	 */
-	public function testNotEquals( Diff $diff, $target ) {
-		$this->assertFalse( $diff->equals( $target ) );
+	public function testNotEquals(Diff $diff, $target): void {
+		$this->assertFalse($diff->equals($target));
 	}
 
-	public function notEqualsProvider() {
-		return array(
+	public function notEqualsProvider(): array {
+		return [
 			// Not an instance or subclass of Diff
-			array( new Diff(), null ),
-			array( new Diff(), new DiffOpAdd( 1 ) ),
+			[new Diff(), null],
+			[new Diff(), new DiffOpAdd(1)],
 
 			// Empty diffs
-			array( new Diff(), new Diff( array(), false ) ),
-			array( new Diff(), new Diff( array(), true ) ),
+			[new Diff(), new Diff([], false)],
+			[new Diff(), new Diff([], true)],
 
 			// Simple diffs
-			array( new Diff(), new Diff( array( new DiffOpAdd( 1 ) ) ) ),
-			array( new Diff( array( new DiffOpAdd( 1 ) ) ), new Diff( array( new DiffOpRemove( 1 ) ) ) ),
-			array( new Diff( array( new DiffOpAdd( 1 ) ) ), new Diff( array( new DiffOpAdd( 2 ) ) ) ),
-		);
+			[new Diff(), new Diff([new DiffOpAdd(1)])],
+			[new Diff([new DiffOpAdd(1)]), new Diff([new DiffOpRemove(1)])],
+			[new Diff([new DiffOpAdd(1)]), new Diff([new DiffOpAdd(2)])],
+		];
 	}
 
-	public function testWhenThereAreNoChangeOperations_getChangesReturnsEmptyArray() {
+	public function testWhenThereAreNoChangeOperations_getChangesReturnsEmptyArray(): void {
 		$this->assertSame(
 			[],
-			( new Diff( [
-				new DiffOpAdd( 1 ),
-				new DiffOpRemove( 2 )
-			] ) )->getChanges()
+			(new Diff(
+				[
+					new DiffOpAdd(1),
+					new DiffOpRemove(2),
+				]
+			))->getChanges()
 		);
 	}
 
-	public function testWhenThereAreChangeOperations_getChangesReturnsThem() {
+	public function testWhenThereAreChangeOperations_getChangesReturnsThem(): void {
 		$changeOperations = [
-			new DiffOpChange( 1, 2 ),
-			new DiffOpChange( 3, 4 )
+			new DiffOpChange(1, 2),
+			new DiffOpChange(3, 4),
 		];
 
 		$this->assertEquals(
 			$changeOperations,
-			( new Diff( $changeOperations ) )->getChanges()
+			(new Diff($changeOperations))->getChanges()
 		);
 	}
 

--- a/tests/unit/DiffOp/DiffOpAddTest.php
+++ b/tests/unit/DiffOp/DiffOpAddTest.php
@@ -1,62 +1,62 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace Diff\Tests\DiffOp;
 
 use Diff\DiffOp\DiffOpAdd;
 
 /**
- * @covers \Diff\DiffOp\DiffOpAdd
- * @covers \Diff\DiffOp\AtomicDiffOp
+ * @covers  \Diff\DiffOp\DiffOpAdd
+ * @covers  \Diff\DiffOp\AtomicDiffOp
  *
- * @group Diff
- * @group DiffOp
+ * @group   Diff
+ * @group   DiffOp
  *
  * @license BSD-3-Clause
- * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author  Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class DiffOpAddTest extends DiffOpTest {
 
 	/**
-	 * @see DiffOpTest::getClass
-	 *
+	 * @return string
 	 * @since 0.1
 	 *
-	 * @return string
+	 * @see   DiffOpTest::getClass
+	 *
 	 */
-	public function getClass() {
+	public function getClass(): string {
 		return '\Diff\DiffOp\DiffOpAdd';
 	}
 
 	/**
-	 * @see DiffOpTest::constructorProvider
+	 * @see   DiffOpTest::constructorProvider
 	 *
 	 * @since 0.1
 	 */
-	public function constructorProvider() {
-		return array(
-			array( true, 'foo' ),
-			array( true, array() ),
-			array( true, true ),
-			array( true, 42 ),
-			array( true, new DiffOpAdd( 'spam' ) ),
-		);
+	public function constructorProvider(): array {
+		return [
+			[true, 'foo'],
+			[true, []],
+			[true, true],
+			[true, 42],
+			[true, new DiffOpAdd('spam')],
+		];
 	}
 
 	/**
 	 * @dataProvider instanceProvider
 	 */
-	public function testGetNewValue( DiffOpAdd $diffOp, array $constructorArgs ) {
-		$this->assertEquals( $constructorArgs[0], $diffOp->getNewValue() );
+	public function testGetNewValue(DiffOpAdd $diffOp, array $constructorArgs): void {
+		$this->assertEquals($constructorArgs[0], $diffOp->getNewValue());
 	}
 
 	/**
 	 * @dataProvider instanceProvider
 	 */
-	public function testToArrayMore( DiffOpAdd $diffOp ) {
+	public function testToArrayMore(DiffOpAdd $diffOp): void {
 		$array = $diffOp->toArray();
-		$this->assertArrayHasKey( 'newvalue', $array );
+		$this->assertArrayHasKey('newvalue', $array);
 	}
 
 }

--- a/tests/unit/DiffOp/DiffOpChangeTest.php
+++ b/tests/unit/DiffOp/DiffOpChangeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace Diff\Tests\DiffOp;
 
@@ -8,63 +8,63 @@ use Diff\DiffOp\DiffOpAdd;
 use Diff\DiffOp\DiffOpChange;
 
 /**
- * @covers \Diff\DiffOp\DiffOpChange
- * @covers \Diff\DiffOp\AtomicDiffOp
+ * @covers  \Diff\DiffOp\DiffOpChange
+ * @covers  \Diff\DiffOp\AtomicDiffOp
  *
- * @group Diff
- * @group DiffOp
+ * @group   Diff
+ * @group   DiffOp
  *
  * @license BSD-3-Clause
- * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author  Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class DiffOpChangeTest extends DiffOpTest {
 
 	/**
-	 * @see DiffOpTest::getClass
-	 *
+	 * @return string
 	 * @since 0.1
 	 *
-	 * @return string
+	 * @see   DiffOpTest::getClass
+	 *
 	 */
-	public function getClass() {
+	public function getClass(): string {
 		return '\Diff\DiffOp\DiffOpChange';
 	}
 
 	/**
-	 * @see DiffOpTest::constructorProvider
+	 * @see   DiffOpTest::constructorProvider
 	 *
 	 * @since 0.1
 	 */
-	public function constructorProvider() {
-		return array(
-			array( true, 'foo', 'bar' ),
-			array( true, array( 9001 ), array( 4, 2 ) ),
-			array( true, true, false ),
-			array( true, true, true ),
-			array( true, 42, 4.2 ),
-			array( true, 42, 42 ),
-			array( true, 'foo', array( 'foo' ) ),
-			array( true, 'foo', null ),
-			array( true, new DiffOpAdd( 'ham' ), new DiffOpAdd( 'spam' ) ),
-			array( true, null, null ),
-		);
+	public function constructorProvider(): array {
+		return [
+			[true, 'foo', 'bar'],
+			[true, [9001], [4, 2]],
+			[true, true, false],
+			[true, true, true],
+			[true, 42, 4.2],
+			[true, 42, 42],
+			[true, 'foo', ['foo']],
+			[true, 'foo', null],
+			[true, new DiffOpAdd('ham'), new DiffOpAdd('spam')],
+			[true, null, null],
+		];
 	}
 
 	/**
 	 * @dataProvider instanceProvider
 	 */
-	public function testGetNewValue( DiffOpChange $diffOp, array $constructorArgs ) {
-		$this->assertEquals( $constructorArgs[0], $diffOp->getOldValue() );
-		$this->assertEquals( $constructorArgs[1], $diffOp->getNewValue() );
+	public function testGetNewValue(DiffOpChange $diffOp, array $constructorArgs): void {
+		$this->assertEquals($constructorArgs[0], $diffOp->getOldValue());
+		$this->assertEquals($constructorArgs[1], $diffOp->getNewValue());
 	}
 
 	/**
 	 * @dataProvider instanceProvider
 	 */
-	public function testToArrayMore( DiffOpChange $diffOp ) {
+	public function testToArrayMore(DiffOpChange $diffOp): void {
 		$array = $diffOp->toArray();
-		$this->assertArrayHasKey( 'newvalue', $array );
-		$this->assertArrayHasKey( 'oldvalue', $array );
+		$this->assertArrayHasKey('newvalue', $array);
+		$this->assertArrayHasKey('oldvalue', $array);
 	}
 
 }

--- a/tests/unit/DiffOp/DiffOpRemoveTest.php
+++ b/tests/unit/DiffOp/DiffOpRemoveTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace Diff\Tests\DiffOp;
 
@@ -8,56 +8,56 @@ use Diff\DiffOp\DiffOpAdd;
 use Diff\DiffOp\DiffOpRemove;
 
 /**
- * @covers \Diff\DiffOp\DiffOpRemove
- * @covers \Diff\DiffOp\AtomicDiffOp
+ * @covers  \Diff\DiffOp\DiffOpRemove
+ * @covers  \Diff\DiffOp\AtomicDiffOp
  *
- * @group Diff
- * @group DiffOp
+ * @group   Diff
+ * @group   DiffOp
  *
  * @license BSD-3-Clause
- * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author  Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class DiffOpRemoveTest extends DiffOpTest {
 
 	/**
-	 * @see DiffOpTest::getClass
-	 *
+	 * @return string
 	 * @since 0.1
 	 *
-	 * @return string
+	 * @see   DiffOpTest::getClass
+	 *
 	 */
-	public function getClass() {
+	public function getClass(): string {
 		return '\Diff\DiffOp\DiffOpRemove';
 	}
 
 	/**
-	 * @see DiffOpTest::constructorProvider
+	 * @see   DiffOpTest::constructorProvider
 	 *
 	 * @since 0.1
 	 */
-	public function constructorProvider() {
-		return array(
-			array( true, 'foo' ),
-			array( true, array() ),
-			array( true, true ),
-			array( true, 42 ),
-			array( true, new DiffOpAdd( 'spam' ) ),
-		);
+	public function constructorProvider(): array {
+		return [
+			[true, 'foo'],
+			[true, []],
+			[true, true],
+			[true, 42],
+			[true, new DiffOpAdd('spam')],
+		];
 	}
 
 	/**
 	 * @dataProvider instanceProvider
 	 */
-	public function testGetNewValue( DiffOpRemove $diffOp, array $constructorArgs ) {
-		$this->assertEquals( $constructorArgs[0], $diffOp->getOldValue() );
+	public function testGetNewValue(DiffOpRemove $diffOp, array $constructorArgs): void {
+		$this->assertEquals($constructorArgs[0], $diffOp->getOldValue());
 	}
 
 	/**
 	 * @dataProvider instanceProvider
 	 */
-	public function testToArrayMore( DiffOpRemove $diffOp ) {
+	public function testToArrayMore(DiffOpRemove $diffOp): void {
 		$array = $diffOp->toArray();
-		$this->assertArrayHasKey( 'oldvalue', $array );
+		$this->assertArrayHasKey('oldvalue', $array);
 	}
 
 }

--- a/tests/unit/DiffOpFactoryTest.php
+++ b/tests/unit/DiffOpFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace Diff\Tests;
 
@@ -12,37 +12,37 @@ use Diff\DiffOp\DiffOpRemove;
 use Diff\DiffOpFactory;
 
 /**
- * @covers \Diff\DiffOpFactory
+ * @covers  \Diff\DiffOpFactory
  *
- * @group Diff
+ * @group   Diff
  *
  * @license BSD-3-Clause
- * @author Jeroen De Dauw < jeroendedauw@gmail.com >
- * @author Daniel Kinzler
+ * @author  Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author  Daniel Kinzler
  */
 class DiffOpFactoryTest extends DiffTestCase {
 
-	public function diffOpProvider() {
-		$diffOps = array();
+	public function diffOpProvider(): array {
+		$diffOps = [];
 
-		$diffOps[] = new DiffOpAdd( 42 );
-		$diffOps['foo bar'] = new DiffOpAdd( '42' );
-		$diffOps[9001] = new DiffOpAdd( 4.2 );
-		$diffOps['42'] = new DiffOpAdd( array( 42, array( 9001 ) ) );
-		$diffOps[] = new DiffOpRemove( 42 );
-		$diffOps[] = new DiffOpAdd( new DiffOpChange( 'spam', 'moar spam' ) );
+		$diffOps[] = new DiffOpAdd(42);
+		$diffOps['foo bar'] = new DiffOpAdd('42');
+		$diffOps[9001] = new DiffOpAdd(4.2);
+		$diffOps['42'] = new DiffOpAdd([42, [9001]]);
+		$diffOps[] = new DiffOpRemove(42);
+		$diffOps[] = new DiffOpAdd(new DiffOpChange('spam', 'moar spam'));
 
 		$atomicDiffOps = $diffOps;
 
-		foreach ( array( true, false, null ) as $isAssoc ) {
-			$diffOps[] = new Diff( $atomicDiffOps, $isAssoc );
+		foreach ([true, false, null] as $isAssoc) {
+			$diffOps[] = new Diff($atomicDiffOps, $isAssoc);
 		}
 
-		$diffOps[] = new DiffOpChange( 42, '9001' );
+		$diffOps[] = new DiffOpChange(42, '9001');
 
-		$diffOps[] = new Diff( $diffOps );
+		$diffOps[] = new Diff($diffOps);
 
-		return $this->arrayWrap( $diffOps );
+		return $this->arrayWrap($diffOps);
 	}
 
 	/**
@@ -50,16 +50,16 @@ class DiffOpFactoryTest extends DiffTestCase {
 	 *
 	 * @param DiffOp $diffOp
 	 */
-	public function testNewFromArray( DiffOp $diffOp ) {
+	public function testNewFromArray(DiffOp $diffOp): void {
 		$factory = new DiffOpFactory();
 
 		// try without conversion callback
 		$array = $diffOp->toArray();
-		$newInstance = $factory->newFromArray( $array );
+		$newInstance = $factory->newFromArray($array);
 
 		// If an equality method is implemented in DiffOp, it should be used here
-		$this->assertEquals( $diffOp, $newInstance );
-		$this->assertEquals( $diffOp->getType(), $newInstance->getType() );
+		$this->assertEquals($diffOp, $newInstance);
+		$this->assertEquals($diffOp->getType(), $newInstance->getType());
 	}
 
 	/**
@@ -67,52 +67,52 @@ class DiffOpFactoryTest extends DiffTestCase {
 	 *
 	 * @param DiffOp $diffOp
 	 */
-	public function testNewFromArrayWithConversion( DiffOp $diffOp ) {
-		$unserializationFunction = function( $array ) {
-			if ( is_array( $array ) && isset( $array['type'] ) && $array['type'] === 'Change' ) {
-				return new DiffOpChange( $array['teh_old'], $array['teh_new'] );
+	public function testNewFromArrayWithConversion(DiffOp $diffOp): void {
+		$unserializationFunction = function ($array) {
+			if (is_array($array) && isset($array['type']) && $array['type'] === 'Change') {
+				return new DiffOpChange($array['teh_old'], $array['teh_new']);
 			}
 
 			return $array;
 		};
 
-		$factory = new DiffOpFactory( $unserializationFunction );
+		$factory = new DiffOpFactory($unserializationFunction);
 
-		$serializationFunction = function( $obj ) {
-			if ( $obj instanceof DiffOpChange ) {
-				return array(
+		$serializationFunction = function ($obj) {
+			if ($obj instanceof DiffOpChange) {
+				return [
 					'type' => 'Change',
 					'teh_old' => $obj->getOldValue(),
 					'teh_new' => $obj->getNewValue(),
-				);
+				];
 			}
 
 			return $obj;
 		};
 
 		// try with conversion callback
-		$array = $diffOp->toArray( $serializationFunction );
+		$array = $diffOp->toArray($serializationFunction);
 
-		$newInstance = $factory->newFromArray( $array );
+		$newInstance = $factory->newFromArray($array);
 
 		// If an equality method is implemented in DiffOp, it should be used here
-		$this->assertEquals( $diffOp, $newInstance );
-		$this->assertEquals( $diffOp->getType(), $newInstance->getType() );
+		$this->assertEquals($diffOp, $newInstance);
+		$this->assertEquals($diffOp->getType(), $newInstance->getType());
 	}
 
-	public function invalidArrayFromArrayProvider() {
-		return array(
-			array( array() ),
-			array( array( '~=[,,_,,]:3' ) ),
-			array( array( '~=[,,_,,]:3' => '~=[,,_,,]:3' ) ),
-			array( array( 'type' => '~=[,,_,,]:3' ) ),
-			array( array( 'type' => 'add', 'oldvalue' => 'foo' ) ),
-			array( array( 'type' => 'remove', 'newvalue' => 'foo' ) ),
-			array( array( 'type' => 'change', 'newvalue' => 'foo' ) ),
-			array( array( 'diff' => 'remove', 'newvalue' => 'foo' ) ),
-			array( array( 'diff' => 'remove', 'operations' => array() ) ),
-			array( array( 'diff' => 'remove', 'isassoc' => true ) ),
-		);
+	public function invalidArrayFromArrayProvider(): array {
+		return [
+			[[]],
+			[['~=[,,_,,]:3']],
+			[['~=[,,_,,]:3' => '~=[,,_,,]:3']],
+			[['type' => '~=[,,_,,]:3']],
+			[['type' => 'add', 'oldvalue' => 'foo']],
+			[['type' => 'remove', 'newvalue' => 'foo']],
+			[['type' => 'change', 'newvalue' => 'foo']],
+			[['diff' => 'remove', 'newvalue' => 'foo']],
+			[['diff' => 'remove', 'operations' => []]],
+			[['diff' => 'remove', 'isassoc' => true]],
+		];
 	}
 
 	/**
@@ -120,11 +120,11 @@ class DiffOpFactoryTest extends DiffTestCase {
 	 *
 	 * @param array $array
 	 */
-	public function testNewFromArrayInvalid( array $array ) {
-		$this->expectException( 'InvalidArgumentException' );
+	public function testNewFromArrayInvalid(array $array): void {
+		$this->expectException('InvalidArgumentException');
 
 		$factory = new DiffOpFactory();
-		$factory->newFromArray( $array );
+		$factory->newFromArray($array);
 	}
 
 }

--- a/tests/unit/DiffTestCase.php
+++ b/tests/unit/DiffTestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace Diff\Tests;
 
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
  * Base class for unit tests in the Diff library.
  *
  * @license BSD-3-Clause
- * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author  Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 abstract class DiffTestCase extends TestCase {
 
@@ -19,16 +19,16 @@ abstract class DiffTestCase extends TestCase {
 	 * each element in it's own array. Useful for data providers
 	 * that only return a single argument.
 	 *
-	 * @since 0.6
-	 *
 	 * @param array $elements
 	 *
 	 * @return array[]
+	 * @since 0.6
+	 *
 	 */
-	protected function arrayWrap( array $elements ) {
+	protected function arrayWrap(array $elements): array {
 		return array_map(
-			function( $element ) {
-				return array( $element );
+			function ($element) {
+				return [$element];
 			},
 			$elements
 		);
@@ -39,32 +39,32 @@ abstract class DiffTestCase extends TestCase {
 	 * the same set of values. Using additional arguments, order and associated key can also
 	 * be set as relevant.
 	 *
+	 * @param array  $expected
+	 * @param array  $actual
+	 * @param bool   $ordered If the order of the values should match
+	 * @param bool   $named   If the keys should match
+	 * @param string $message
 	 * @since 0.6
 	 *
-	 * @param array $expected
-	 * @param array $actual
-	 * @param bool $ordered If the order of the values should match
-	 * @param bool $named If the keys should match
-	 * @param string $message
 	 */
 	protected function assertArrayEquals(
-		array $expected,
-		array $actual,
-		$ordered = false,
-		$named = false,
-		$message = ''
+		array  $expected,
+		array  $actual,
+		bool   $ordered = false,
+		bool   $named = false,
+		string $message = ''
 	) {
-		if ( !$ordered ) {
-			$this->objectAssociativeSort( $expected );
-			$this->objectAssociativeSort( $actual );
+		if (!$ordered) {
+			$this->objectAssociativeSort($expected);
+			$this->objectAssociativeSort($actual);
 		}
 
-		if ( !$named ) {
-			$expected = array_values( $expected );
-			$actual = array_values( $actual );
+		if (!$named) {
+			$expected = array_values($expected);
+			$actual = array_values($actual);
 		}
 
-		$this->assertEquals( $expected, $actual, $message );
+		$this->assertEquals($expected, $actual, $message);
 	}
 
 	/**
@@ -72,11 +72,11 @@ abstract class DiffTestCase extends TestCase {
 	 *
 	 * @param array $array
 	 */
-	private function objectAssociativeSort( array &$array ) {
+	private function objectAssociativeSort(array &$array): void {
 		uasort(
 			$array,
-			function ( $a, $b ) {
-				return serialize( $a ) > serialize( $b ) ? 1 : -1;
+			function ($a, $b) {
+				return serialize($a) > serialize($b) ? 1 : -1;
 			}
 		);
 	}

--- a/tests/unit/Differ/CallbackListDifferTest.php
+++ b/tests/unit/Differ/CallbackListDifferTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace Diff\Tests\Differ;
 
@@ -9,148 +9,205 @@ use Diff\Differ\Differ;
 use Diff\DiffOp\DiffOpAdd;
 use Diff\DiffOp\DiffOpRemove;
 use Diff\Tests\DiffTestCase;
+use stdClass;
 
 /**
- * @covers \Diff\Differ\CallbackListDiffer
+ * @covers  \Diff\Differ\CallbackListDiffer
  *
- * @group Diff
- * @group Differ
+ * @group   Diff
+ * @group   Differ
  *
  * @license BSD-3-Clause
- * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author  Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class CallbackListDifferTest extends DiffTestCase {
 
-	/**
-	 * Returns those that both work for native and strict mode.
-	 */
-	private function getCommonArgLists() {
-		$argLists = array();
+	public function toDiffProvider(): array {
+		$argLists = $this->getCommonArgLists();
 
-		$old = array();
-		$new = array();
-		$expected = array();
+		$old = [42, 42];
+		$new = [42];
+		$expected = [new DiffOpRemove(42)];
 
-		$argLists[] = array( $old, $new, $expected,
-			'There should be no difference between empty arrays' );
-
-		$old = array( 42 );
-		$new = array( 42 );
-		$expected = array();
-
-		$argLists[] = array( $old, $new, $expected,
-			'There should be no difference between arrays with the same element' );
-
-		$old = array( 42, 'ohi', 4.2, false );
-		$new = array( 42, 'ohi', 4.2, false );
-		$expected = array();
-
-		$argLists[] = array( $old, $new, $expected,
-			'There should be no difference between arrays with the same elements' );
-
-		$old = array( 42, 'ohi', 4.2, false );
-		$new = array( false, 4.2, 'ohi', 42 );
-		$expected = array();
-
-		$argLists[] = array( $old, $new, $expected,
-			'There should be no difference between arrays with the same elements even when not ordered the same' );
-
-		$old = array();
-		$new = array( 42 );
-		$expected = array( new DiffOpAdd( 42 ) );
-
-		$argLists[] = array( $old, $new, $expected,
-			'An array with a single element should be an add operation different from an empty array' );
-
-		$old = array( 42 );
-		$new = array();
-		$expected = array( new DiffOpRemove( 42 ) );
-
-		$argLists[] = array( $old, $new, $expected,
-			'An empty array should be a remove operation different from an array with one element' );
-
-		$old = array( 1 );
-		$new = array( 2 );
-		$expected = array( new DiffOpRemove( 1 ), new DiffOpAdd( 2 ) );
-
-		$argLists[] = array( $old, $new, $expected,
-			'Two arrays with a single different element should differ by an add and a remove op' );
-
-		$old = array( 9001, 42, 1, 0 );
-		$new = array( 9001, 2, 0, 42 );
-		$expected = array( new DiffOpRemove( 1 ), new DiffOpAdd( 2 ) );
-
-		$argLists[] = array(
+		$argLists[] = [
 			$old,
 			$new,
 			$expected,
-			'Two arrays with a single different element should differ by an add '
-				. 'and a remove op even when they share identical elements'
-		);
+			'[42, 42] to [42] should [rem(42)]',
+		];
 
-		return $argLists;
-	}
+		$old = [42];
+		$new = [42, 42];
+		$expected = [new DiffOpAdd(42)];
 
-	public function toDiffProvider() {
-		$argLists = $this->getCommonArgLists();
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'[42] to [42, 42] should [add(42)]',
+		];
 
-		$old = array( 42, 42 );
-		$new = array( 42 );
-		$expected = array( new DiffOpRemove( 42 ) );
+		$old = ['42'];
+		$new = [42];
+		$expected = [new DiffOpRemove('42'), new DiffOpAdd(42)];
 
-		$argLists[] = array( $old, $new, $expected,
-			'[42, 42] to [42] should [rem(42)]' );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'["42"] to [42] should [rem("42"), add(42)]',
+		];
 
-		$old = array( 42 );
-		$new = array( 42, 42 );
-		$expected = array( new DiffOpAdd( 42 ) );
+		$old = [[1]];
+		$new = [[2]];
+		$expected = [new DiffOpRemove([1]), new DiffOpAdd([2])];
 
-		$argLists[] = array( $old, $new, $expected,
-			'[42] to [42, 42] should [add(42)]' );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'[[1]] to [[2]] should [rem([1]), add([2])]',
+		];
 
-		$old = array( '42' );
-		$new = array( 42 );
-		$expected = array( new DiffOpRemove( '42' ), new DiffOpAdd( 42 ) );
+		$old = [[2]];
+		$new = [[2]];
+		$expected = [];
 
-		$argLists[] = array( $old, $new, $expected,
-			'["42"] to [42] should [rem("42"), add(42)]' );
-
-		$old = array( array( 1 ) );
-		$new = array( array( 2 ) );
-		$expected = array( new DiffOpRemove( array( 1 ) ), new DiffOpAdd( array( 2 ) ) );
-
-		$argLists[] = array( $old, $new, $expected,
-			'[[1]] to [[2]] should [rem([1]), add([2])]' );
-
-		$old = array( array( 2 ) );
-		$new = array( array( 2 ) );
-		$expected = array();
-
-		$argLists[] = array( $old, $new, $expected,
-			'[[2]] to [[2]] should result in an empty diff' );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'[[2]] to [[2]] should result in an empty diff',
+		];
 
 		// test "soft" object comparison
-		$obj1 = new \stdClass();
-		$obj2 = new \stdClass();
-		$objX = new \stdClass();
+		$obj1 = new stdClass();
+		$obj2 = new stdClass();
+		$objX = new stdClass();
 
 		$obj1->test = 'Test';
 		$obj2->test = 'Test';
 		$objX->xest = 'Test';
 
-		$old = array( $obj1 );
-		$new = array( $obj2 );
-		$expected = array( );
+		$old = [$obj1];
+		$new = [$obj2];
+		$expected = [];
 
-		$argLists[] = array( $old, $new, $expected,
-			'Two arrays containing equivalent objects should result in an empty diff' );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'Two arrays containing equivalent objects should result in an empty diff',
+		];
 
-		$old = array( $obj1 );
-		$new = array( $objX );
-		$expected = array( new DiffOpRemove( $obj1 ), new DiffOpAdd( $objX )  );
+		$old = [$obj1];
+		$new = [$objX];
+		$expected = [new DiffOpRemove($obj1), new DiffOpAdd($objX)];
 
-		$argLists[] = array( $old, $new, $expected,
-			'Two arrays containing different objects of the same type should result in an add and a remove op.' );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'Two arrays containing different objects of the same type should result in an add and a remove op.',
+		];
+
+		return $argLists;
+	}
+
+	/**
+	 * Returns those that both work for native and strict mode.
+	 */
+	private function getCommonArgLists(): array {
+		$argLists = [];
+
+		$old = [];
+		$new = [];
+		$expected = [];
+
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'There should be no difference between empty arrays',
+		];
+
+		$old = [42];
+		$new = [42];
+		$expected = [];
+
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'There should be no difference between arrays with the same element',
+		];
+
+		$old = [42, 'ohi', 4.2, false];
+		$new = [42, 'ohi', 4.2, false];
+		$expected = [];
+
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'There should be no difference between arrays with the same elements',
+		];
+
+		$old = [42, 'ohi', 4.2, false];
+		$new = [false, 4.2, 'ohi', 42];
+		$expected = [];
+
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'There should be no difference between arrays with the same elements even when not ordered the same',
+		];
+
+		$old = [];
+		$new = [42];
+		$expected = [new DiffOpAdd(42)];
+
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'An array with a single element should be an add operation different from an empty array',
+		];
+
+		$old = [42];
+		$new = [];
+		$expected = [new DiffOpRemove(42)];
+
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'An empty array should be a remove operation different from an array with one element',
+		];
+
+		$old = [1];
+		$new = [2];
+		$expected = [new DiffOpRemove(1), new DiffOpAdd(2)];
+
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'Two arrays with a single different element should differ by an add and a remove op',
+		];
+
+		$old = [9001, 42, 1, 0];
+		$new = [9001, 2, 0, 42];
+		$expected = [new DiffOpRemove(1), new DiffOpAdd(2)];
+
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'Two arrays with a single different element should differ by an add '
+			. 'and a remove op even when they share identical elements',
+		];
 
 		return $argLists;
 	}
@@ -158,34 +215,34 @@ class CallbackListDifferTest extends DiffTestCase {
 	/**
 	 * @dataProvider toDiffProvider
 	 */
-	public function testDoDiff( $old, $new, $expected, $message = '' ) {
-		$callback = function( $foo, $bar ) {
-			return is_object( $foo ) ? $foo == $bar : $foo === $bar;
+	public function testDoDiff($old, $new, $expected, $message = ''): void {
+		$callback = function ($foo, $bar) {
+			return is_object($foo) ? $foo == $bar : $foo === $bar;
 		};
 
-		$this->doTestDiff( new CallbackListDiffer( $callback ), $old, $new, $expected, $message );
+		$this->doTestDiff(new CallbackListDiffer($callback), $old, $new, $expected, $message);
 	}
 
-	private function doTestDiff( Differ $differ, $old, $new, $expected, $message ) {
-		$actual = $differ->doDiff( $old, $new );
+	private function doTestDiff(Differ $differ, $old, $new, $expected, $message): void {
+		$actual = $differ->doDiff($old, $new);
 
-		$this->assertArrayEquals( $expected, $actual, false, false, $message );
+		$this->assertArrayEquals($expected, $actual, false, false, $message);
 	}
 
-	public function testCallbackComparisonReturningFalse() {
-		$differ = new CallbackListDiffer( function() {
+	public function testCallbackComparisonReturningFalse(): void {
+		$differ = new CallbackListDiffer(function () {
 			return false;
-		} );
+		});
 
-		$actual = $differ->doDiff( array( 1, '2' ), array( 1, '2', 'foo' ) );
+		$actual = $differ->doDiff([1, '2'], [1, '2', 'foo']);
 
-		$expected = array(
-			new DiffOpAdd( 1 ),
-			new DiffOpAdd( '2' ),
-			new DiffOpAdd( 'foo' ),
-			new DiffOpRemove( 1 ),
-			new DiffOpRemove( '2' ),
-		);
+		$expected = [
+			new DiffOpAdd(1),
+			new DiffOpAdd('2'),
+			new DiffOpAdd('foo'),
+			new DiffOpRemove(1),
+			new DiffOpRemove('2'),
+		];
 
 		$this->assertArrayEquals(
 			$expected, $actual, false, false,
@@ -193,14 +250,14 @@ class CallbackListDifferTest extends DiffTestCase {
 		);
 	}
 
-	public function testCallbackComparisonReturningTrue() {
-		$differ = new CallbackListDiffer( function() {
+	public function testCallbackComparisonReturningTrue(): void {
+		$differ = new CallbackListDiffer(function () {
 			return true;
-		} );
+		});
 
-		$actual = $differ->doDiff( array( 1, '2', 'baz' ), array( 1, 'foo', '2' ) );
+		$actual = $differ->doDiff([1, '2', 'baz'], [1, 'foo', '2']);
 
-		$expected = array();
+		$expected = [];
 
 		$this->assertArrayEquals(
 			$expected, $actual, false, false,
@@ -208,14 +265,14 @@ class CallbackListDifferTest extends DiffTestCase {
 		);
 	}
 
-	public function testCallbackComparisonReturningNyanCat() {
-		$differ = new CallbackListDiffer( function() {
+	public function testCallbackComparisonReturningNyanCat(): void {
+		$differ = new CallbackListDiffer(function () {
 			return '~=[,,_,,]:3';
-		} );
+		});
 
-		$this->expectException( 'RuntimeException' );
+		$this->expectException('RuntimeException');
 
-		$differ->doDiff( array( 1, '2', 'baz' ), array( 1, 'foo', '2' ) );
+		$differ->doDiff([1, '2', 'baz'], [1, 'foo', '2']);
 	}
 
 }

--- a/tests/unit/Differ/ListDifferTest.php
+++ b/tests/unit/Differ/ListDifferTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace Diff\Tests\Differ;
 
@@ -11,167 +11,224 @@ use Diff\Differ\ListDiffer;
 use Diff\DiffOp\DiffOpAdd;
 use Diff\DiffOp\DiffOpRemove;
 use Diff\Tests\DiffTestCase;
+use stdClass;
 
 /**
- * @covers \Diff\Differ\ListDiffer
+ * @covers  \Diff\Differ\ListDiffer
  *
- * @group Diff
- * @group Differ
+ * @group   Diff
+ * @group   Differ
  *
  * @license BSD-3-Clause
- * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author  Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class ListDifferTest extends DiffTestCase {
 
-	public function arrayComparerProvider() {
-		$add = array( new DiffOpAdd( 1 ) );
+	public function arrayComparerProvider(): array {
+		$add = [new DiffOpAdd(1)];
 
-		return array(
-			'null' => array( null, $add ),
-			'native object' => array( new NativeArrayComparer(), array() ),
-			'strict object' => array( new StrictArrayComparer(), $add ),
-		);
+		return [
+			'null' => [null, $add],
+			'native object' => [new NativeArrayComparer(), []],
+			'strict object' => [new StrictArrayComparer(), $add],
+		];
 	}
 
 	/**
 	 * @dataProvider arrayComparerProvider
 	 */
-	public function testConstructor( $arrayComparer, array $expected ) {
-		$differ = new ListDiffer( $arrayComparer );
-		$diff = $differ->doDiff( array( 1 ), array( 1, 1 ) );
-		$this->assertEquals( $expected, $diff );
-	}
-
-	/**
-	 * Returns those that both work for native and strict mode.
-	 */
-	private function getCommonArgLists() {
-		$argLists = array();
-
-		$old = array();
-		$new = array();
-		$expected = array();
-
-		$argLists[] = array( $old, $new, $expected,
-			'There should be no difference between empty arrays' );
-
-		$old = array( 42 );
-		$new = array( 42 );
-		$expected = array();
-
-		$argLists[] = array( $old, $new, $expected,
-			'There should be no difference between arrays with the same element' );
-
-		$old = array( 42, 'ohi', 4.2, false );
-		$new = array( 42, 'ohi', 4.2, false );
-		$expected = array();
-
-		$argLists[] = array( $old, $new, $expected,
-			'There should be no difference between arrays with the same elements' );
-
-		$old = array( 42, 'ohi', 4.2, false );
-		$new = array( false, 4.2, 'ohi', 42 );
-		$expected = array();
-
-		$argLists[] = array( $old, $new, $expected,
-			'There should be no difference between arrays with the same elements even when not ordered the same' );
-
-		$old = array();
-		$new = array( 42 );
-		$expected = array( new DiffOpAdd( 42 ) );
-
-		$argLists[] = array( $old, $new, $expected,
-			'An array with a single element should be an add operation different from an empty array' );
-
-		$old = array( 42 );
-		$new = array();
-		$expected = array( new DiffOpRemove( 42 ) );
-
-		$argLists[] = array( $old, $new, $expected,
-			'An empty array should be a remove operation different from an array with one element' );
-
-		$old = array( 1 );
-		$new = array( 2 );
-		$expected = array( new DiffOpRemove( 1 ), new DiffOpAdd( 2 ) );
-
-		$argLists[] = array( $old, $new, $expected,
-			'Two arrays with a single different element should differ by an add and a remove op' );
-
-		$old = array( 9001, 42, 1, 0 );
-		$new = array( 9001, 2, 0, 42 );
-		$expected = array( new DiffOpRemove( 1 ), new DiffOpAdd( 2 ) );
-
-		$argLists[] = array(
-			$old,
-			$new,
-			$expected,
-			'Two arrays with a single different element should differ by an add'
-				. 'and a remove op even when they share identical elements'
-		);
-
-		return $argLists;
+	public function testConstructor($arrayComparer, array $expected) {
+		$differ = new ListDiffer($arrayComparer);
+		$diff = $differ->doDiff([1], [1, 1]);
+		$this->assertEquals($expected, $diff);
 	}
 
 	public function toDiffProvider() {
 		$argLists = $this->getCommonArgLists();
 
-		$old = array( 42, 42 );
-		$new = array( 42 );
-		$expected = array( new DiffOpRemove( 42 ) );
+		$old = [42, 42];
+		$new = [42];
+		$expected = [new DiffOpRemove(42)];
 
-		$argLists[] = array( $old, $new, $expected,
-			'[42, 42] to [42] should [rem(42)]' );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'[42, 42] to [42] should [rem(42)]',
+		];
 
-		$old = array( 42 );
-		$new = array( 42, 42 );
-		$expected = array( new DiffOpAdd( 42 ) );
+		$old = [42];
+		$new = [42, 42];
+		$expected = [new DiffOpAdd(42)];
 
-		$argLists[] = array( $old, $new, $expected,
-			'[42] to [42, 42] should [add(42)]' );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'[42] to [42, 42] should [add(42)]',
+		];
 
-		$old = array( '42' );
-		$new = array( 42 );
-		$expected = array( new DiffOpRemove( '42' ), new DiffOpAdd( 42 ) );
+		$old = ['42'];
+		$new = [42];
+		$expected = [new DiffOpRemove('42'), new DiffOpAdd(42)];
 
-		$argLists[] = array( $old, $new, $expected,
-			'["42"] to [42] should [rem("42"), add(42)]' );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'["42"] to [42] should [rem("42"), add(42)]',
+		];
 
-		$old = array( array( 1 ) );
-		$new = array( array( 2 ) );
-		$expected = array( new DiffOpRemove( array( 1 ) ), new DiffOpAdd( array( 2 ) ) );
+		$old = [[1]];
+		$new = [[2]];
+		$expected = [new DiffOpRemove([1]), new DiffOpAdd([2])];
 
-		$argLists[] = array( $old, $new, $expected,
-			'[[1]] to [[2]] should [rem([1]), add([2])]' );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'[[1]] to [[2]] should [rem([1]), add([2])]',
+		];
 
-		$old = array( array( 2 ) );
-		$new = array( array( 2 ) );
-		$expected = array();
+		$old = [[2]];
+		$new = [[2]];
+		$expected = [];
 
-		$argLists[] = array( $old, $new, $expected,
-			'[[2]] to [[2]] should result in an empty diff' );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'[[2]] to [[2]] should result in an empty diff',
+		];
 
 		// test "soft" object comparison
-		$obj1 = new \stdClass();
-		$obj2 = new \stdClass();
-		$objX = new \stdClass();
+		$obj1 = new stdClass();
+		$obj2 = new stdClass();
+		$objX = new stdClass();
 
 		$obj1->test = 'Test';
 		$obj2->test = 'Test';
 		$objX->xest = 'Test';
 
-		$old = array( $obj1 );
-		$new = array( $obj2 );
-		$expected = array( );
+		$old = [$obj1];
+		$new = [$obj2];
+		$expected = [];
 
-		$argLists[] = array( $old, $new, $expected,
-			'Two arrays containing equivalent objects should result in an empty diff' );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'Two arrays containing equivalent objects should result in an empty diff',
+		];
 
-		$old = array( $obj1 );
-		$new = array( $objX );
-		$expected = array( new DiffOpRemove( $obj1 ), new DiffOpAdd( $objX )  );
+		$old = [$obj1];
+		$new = [$objX];
+		$expected = [new DiffOpRemove($obj1), new DiffOpAdd($objX)];
 
-		$argLists[] = array( $old, $new, $expected,
-			'Two arrays containing different objects of the same type should result in an add and a remove op.' );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'Two arrays containing different objects of the same type should result in an add and a remove op.',
+		];
+
+		return $argLists;
+	}
+
+	/**
+	 * Returns those that both work for native and strict mode.
+	 */
+	private function getCommonArgLists(): array {
+		$argLists = [];
+
+		$old = [];
+		$new = [];
+		$expected = [];
+
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'There should be no difference between empty arrays',
+		];
+
+		$old = [42];
+		$new = [42];
+		$expected = [];
+
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'There should be no difference between arrays with the same element',
+		];
+
+		$old = [42, 'ohi', 4.2, false];
+		$new = [42, 'ohi', 4.2, false];
+		$expected = [];
+
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'There should be no difference between arrays with the same elements',
+		];
+
+		$old = [42, 'ohi', 4.2, false];
+		$new = [false, 4.2, 'ohi', 42];
+		$expected = [];
+
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'There should be no difference between arrays with the same elements even when not ordered the same',
+		];
+
+		$old = [];
+		$new = [42];
+		$expected = [new DiffOpAdd(42)];
+
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'An array with a single element should be an add operation different from an empty array',
+		];
+
+		$old = [42];
+		$new = [];
+		$expected = [new DiffOpRemove(42)];
+
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'An empty array should be a remove operation different from an array with one element',
+		];
+
+		$old = [1];
+		$new = [2];
+		$expected = [new DiffOpRemove(1), new DiffOpAdd(2)];
+
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'Two arrays with a single different element should differ by an add and a remove op',
+		];
+
+		$old = [9001, 42, 1, 0];
+		$new = [9001, 2, 0, 42];
+		$expected = [new DiffOpRemove(1), new DiffOpAdd(2)];
+
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'Two arrays with a single different element should differ by an add'
+			. 'and a remove op even when they share identical elements',
+		];
 
 		return $argLists;
 	}
@@ -179,33 +236,51 @@ class ListDifferTest extends DiffTestCase {
 	/**
 	 * @dataProvider toDiffProvider
 	 */
-	public function testDoDiff( $old, $new, $expected, $message = '' ) {
-		$this->doTestDiff( new ListDiffer(), $old, $new, $expected, $message );
+	public function testDoDiff($old, $new, $expected, $message = ''): void {
+		$this->doTestDiff(new ListDiffer(), $old, $new, $expected, $message);
 	}
 
-	public function toDiffNativeProvider() {
+	private function doTestDiff(Differ $differ, $old, $new, $expected, $message): void {
+		$actual = $differ->doDiff($old, $new);
+
+		$this->assertArrayEquals($expected, $actual, false, false, $message);
+	}
+
+	public function toDiffNativeProvider(): array {
 		$argLists = $this->getCommonArgLists();
 
-		$old = array( '42' );
-		$new = array( 42 );
-		$expected = array();
+		$old = ['42'];
+		$new = [42];
+		$expected = [];
 
-		$argLists[] = array( $old, $new, $expected,
-			'["42"] to [42] should result in an empty diff' );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'["42"] to [42] should result in an empty diff',
+		];
 
-		$old = array( 42, 42 );
-		$new = array( 42 );
-		$expected = array();
+		$old = [42, 42];
+		$new = [42];
+		$expected = [];
 
-		$argLists[] = array( $old, $new, $expected,
-			'[42, 42] to [42] should result in an empty diff' );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'[42, 42] to [42] should result in an empty diff',
+		];
 
-		$old = array( 42 );
-		$new = array( 42, 42 );
-		$expected = array();
+		$old = [42];
+		$new = [42, 42];
+		$expected = [];
 
-		$argLists[] = array( $old, $new, $expected,
-			'[42] to [42, 42] should result in an empty diff' );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'[42] to [42, 42] should result in an empty diff',
+		];
 
 		// TODO: test toString()-based object comparison
 
@@ -215,30 +290,24 @@ class ListDifferTest extends DiffTestCase {
 	/**
 	 * @dataProvider toDiffNativeProvider
 	 */
-	public function testDoNativeDiff( $old, $new, $expected, $message = '' ) {
-		$this->doTestDiff( new ListDiffer( new NativeArrayComparer() ), $old, $new, $expected, $message );
+	public function testDoNativeDiff($old, $new, $expected, $message = ''): void {
+		$this->doTestDiff(new ListDiffer(new NativeArrayComparer()), $old, $new, $expected, $message);
 	}
 
-	private function doTestDiff( Differ $differ, $old, $new, $expected, $message ) {
-		$actual = $differ->doDiff( $old, $new );
+	public function testDiffCallsArrayComparatorCorrectly(): void {
+		$arrayComparer = $this->createMock('Diff\ArrayComparer\ArrayComparer');
 
-		$this->assertArrayEquals( $expected, $actual, false, false, $message );
-	}
-
-	public function testDiffCallsArrayComparatorCorrectly() {
-		$arrayComparer = $this->createMock( 'Diff\ArrayComparer\ArrayComparer' );
-
-		$arrayComparer->expects( $this->exactly( 2 ) )
-			->method( 'diffArrays' )
+		$arrayComparer->expects($this->exactly(2))
+			->method('diffArrays')
 			->with(
-				$this->equalTo( array( 42 ) ),
-				$this->equalTo( array( 42 ) )
+				$this->equalTo([42]),
+				$this->equalTo([42])
 			)
-			->will( $this->returnValue( array() ) );
+			->will($this->returnValue([]));
 
-		$differ = new ListDiffer( $arrayComparer );
+		$differ = new ListDiffer($arrayComparer);
 
-		$differ->doDiff( array( 42 ), array( 42 ) );
+		$differ->doDiff([42], [42]);
 	}
 
 }

--- a/tests/unit/Differ/MapDifferTest.php
+++ b/tests/unit/Differ/MapDifferTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace Diff\Tests\Differ;
 
@@ -16,290 +16,437 @@ use Diff\Tests\DiffTestCase;
 use Diff\Tests\Fixtures\StubValueComparer;
 
 /**
- * @covers \Diff\Differ\MapDiffer
+ * @covers  \Diff\Differ\MapDiffer
  *
- * @group Diff
- * @group Differ
+ * @group   Diff
+ * @group   Differ
  *
  * @license BSD-3-Clause
- * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author  Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class MapDifferTest extends DiffTestCase {
 
-	public function toDiffProvider() {
-		$argLists = array();
+	public function toDiffProvider(): array {
+		$argLists = [];
 
-		$old = array();
-		$new = array();
-		$expected = array();
+		$old = [];
+		$new = [];
+		$expected = [];
 
-		$argLists[] = array( $old, $new, $expected,
-			'There should be no difference between empty arrays' );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'There should be no difference between empty arrays',
+		];
 
-		$old = array( 42 );
-		$new = array( 42 );
-		$expected = array();
+		$old = [42];
+		$new = [42];
+		$expected = [];
 
-		$argLists[] = array( $old, $new, $expected,
-			'There should be no difference between two arrays with the same element' );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'There should be no difference between two arrays with the same element',
+		];
 
-		$old = array( 42, 10, 'ohi', false, null, array( '.', 4.2 ) );
-		$new = array( 42, 10, 'ohi', false, null, array( '.', 4.2 ) );
-		$expected = array();
+		$old = [42, 10, 'ohi', false, null, ['.', 4.2]];
+		$new = [42, 10, 'ohi', false, null, ['.', 4.2]];
+		$expected = [];
 
-		$argLists[] = array( $old, $new, $expected,
-			'There should be no difference between two arrays with the same elements' );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'There should be no difference between two arrays with the same elements',
+		];
 
-		$old = array( 42, 42, 42 );
-		$new = array( 42, 42, 42 );
-		$expected = array();
+		$old = [42, 42, 42];
+		$new = [42, 42, 42];
+		$expected = [];
 
-		$argLists[] = array( $old, $new, $expected,
-			'There should be no difference between two arrays with the same elements' );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'There should be no difference between two arrays with the same elements',
+		];
 
-		$old = array( 1, 2 );
-		$new = array( 2, 1 );
-		$expected = array( new DiffOpChange( 1, 2 ), new DiffOpChange( 2, 1 ) );
+		$old = [1, 2];
+		$new = [2, 1];
+		$expected = [new DiffOpChange(1, 2), new DiffOpChange(2, 1)];
 
-		$argLists[] = array( $old, $new, $expected,
-			'Switching position should cause a diff' );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'Switching position should cause a diff',
+		];
 
-		$old = array( 0, 1, 2, 3 );
-		$new = array( 0, 2, 1, 3 );
-		$expected = array( 1 => new DiffOpChange( 1, 2 ), 2 => new DiffOpChange( 2, 1 ) );
+		$old = [0, 1, 2, 3];
+		$new = [0, 2, 1, 3];
+		$expected = [1 => new DiffOpChange(1, 2), 2 => new DiffOpChange(2, 1)];
 
-		$argLists[] = array( $old, $new, $expected,
-			'Switching position should cause a diff' );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'Switching position should cause a diff',
+		];
 
-		$old = array( 'a' => 0, 'b' => 1, 'c' => 0 );
-		$new = array( 'a' => 42, 'b' => 1, 'c' => 42 );
-		$expected = array( 'a' => new DiffOpChange( 0, 42 ), 'c' => new DiffOpChange( 0, 42 ) );
+		$old = ['a' => 0, 'b' => 1, 'c' => 0];
+		$new = ['a' => 42, 'b' => 1, 'c' => 42];
+		$expected = ['a' => new DiffOpChange(0, 42), 'c' => new DiffOpChange(0, 42)];
 
-		$argLists[] = array( $old, $new, $expected,
-			'Doing the same change to two different elements should result in two identical change ops' );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'Doing the same change to two different elements should result in two identical change ops',
+		];
 
-		$old = array( 'a' => 0, 'b' => 1 );
-		$new = array( 'a' => 0, 'c' => 1 );
-		$expected = array( 'b' => new DiffOpRemove( 1 ), 'c' => new DiffOpAdd( 1 ) );
+		$old = ['a' => 0, 'b' => 1];
+		$new = ['a' => 0, 'c' => 1];
+		$expected = ['b' => new DiffOpRemove(1), 'c' => new DiffOpAdd(1)];
 
-		$argLists[] = array( $old, $new, $expected,
-			'Changing the key of an element should result in a remove and an add op' );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'Changing the key of an element should result in a remove and an add op',
+		];
 
-		$old = array( 'a' => 0, 'b' => 1 );
-		$new = array( 'b' => 1, 'a' => 0 );
-		$expected = array();
+		$old = ['a' => 0, 'b' => 1];
+		$new = ['b' => 1, 'a' => 0];
+		$expected = [];
 
-		$argLists[] = array( $old, $new, $expected,
-			'Changing the order of associative elements should have no effect.' );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'Changing the order of associative elements should have no effect.',
+		];
 
-		$old = array( 'a' => array( 'foo' ) );
-		$new = array( 'a' => array( 'foo' ) );
-		$expected = array();
+		$old = ['a' => ['foo']];
+		$new = ['a' => ['foo']];
+		$expected = [];
 
-		$argLists[] = array( $old, $new, $expected,
-			'Comparing equal substructures without recursion should return nothing.', false );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'Comparing equal substructures without recursion should return nothing.',
+			false,
+		];
 
-		$old = array( );
-		$new = array( 'a' => array( 'foo', 'bar' ) );
-		$expected = array( 'a' => new DiffOpAdd( array( 'foo', 'bar' ) ) );
+		$old = [];
+		$new = ['a' => ['foo', 'bar']];
+		$expected = ['a' => new DiffOpAdd(['foo', 'bar'])];
 
-		$argLists[] = array( $old, $new, $expected,
-			'Adding a substructure should result in a single add operation when not in recursive mode.', false );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'Adding a substructure should result in a single add operation when not in recursive mode.',
+			false,
+		];
 
-		$old = array( 'a' => array( 'b' => 42 ) );
-		$new = array( 'a' => array( 'b' => 7201010 ) );
-		$expected = array( 'a' => new Diff( array( 'b' => new DiffOpChange( 42, 7201010 ) ), true ) );
+		$old = ['a' => ['b' => 42]];
+		$new = ['a' => ['b' => 7201010]];
+		$expected = ['a' => new Diff(['b' => new DiffOpChange(42, 7201010)], true)];
 
-		$argLists[] = array( $old, $new, $expected,
-			'Recursion should work for nested associative diffs', true );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'Recursion should work for nested associative diffs',
+			true,
+		];
 
-		$old = array( 'a' => array( 'foo' ) );
-		$new = array( 'a' => array( 'foo' ) );
-		$expected = array();
+		$old = ['a' => ['foo']];
+		$new = ['a' => ['foo']];
+		$expected = [];
 
-		$argLists[] = array( $old, $new, $expected,
-			'Comparing equal sub-structures with recursion should return nothing.', true );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'Comparing equal sub-structures with recursion should return nothing.',
+			true,
+		];
 
-		$old = array( 'stuff' => array( 'a' => 0, 'b' => 1 ) );
-		$new = array( 'stuff' => array( 'b' => 1, 'a' => 0 ) );
-		$expected = array();
+		$old = ['stuff' => ['a' => 0, 'b' => 1]];
+		$new = ['stuff' => ['b' => 1, 'a' => 0]];
+		$expected = [];
 
-		$argLists[] = array( $old, $new, $expected,
-			'Changing the order of associative elements in a substructure should have no effect.', true );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'Changing the order of associative elements in a substructure should have no effect.',
+			true,
+		];
 
-		$old = array();
-		$new = array( 'stuff' => array( 'b' => 1, 'a' => 0 ) );
-		$expected = array( 'stuff' => new Diff( array( 'b' => new DiffOpAdd( 1 ), 'a' => new DiffOpAdd( 0 ) ) ) );
+		$old = [];
+		$new = ['stuff' => ['b' => 1, 'a' => 0]];
+		$expected = ['stuff' => new Diff(['b' => new DiffOpAdd(1), 'a' => new DiffOpAdd(0)])];
 
-		$argLists[] = array( $old, $new, $expected,
-			'Adding a substructure should be reported as adding *to* a substructure when in recursive mode.', true );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'Adding a substructure should be reported as adding *to* a substructure when in recursive mode.',
+			true,
+		];
 
-		$old = array( 'a' => array( 42, 9001 ), 1 );
-		$new = array( 'a' => array( 42, 7201010 ), 1 );
-		$expected = array( 'a' => new Diff( array( new DiffOpAdd( 7201010 ), new DiffOpRemove( 9001 ) ), false ) );
+		$old = ['a' => [42, 9001], 1];
+		$new = ['a' => [42, 7201010], 1];
+		$expected = ['a' => new Diff([new DiffOpAdd(7201010), new DiffOpRemove(9001)], false)];
 
-		$argLists[] = array( $old, $new, $expected,
-			'Recursion should work for nested non-associative diffs', true );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'Recursion should work for nested non-associative diffs',
+			true,
+		];
 
-		$old = array( array( 42 ), 1 );
-		$new = array( array( 42, 42 ), 1 );
-		$expected = array( new Diff( array( new DiffOpAdd( 42 ) ), false ) );
+		$old = [[42], 1];
+		$new = [[42, 42], 1];
+		$expected = [new Diff([new DiffOpAdd(42)], false)];
 
-		$argLists[] = array( $old, $new, $expected,
-			'Nested non-associative diffs should behave as the default ListDiffer', true );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'Nested non-associative diffs should behave as the default ListDiffer',
+			true,
+		];
 
-		$old = array( array( 42 ), 1 );
-		$new = array( array( 42, 42, 1 ), 1 );
-		$expected = array( new Diff( array( new DiffOpAdd( 1 ) ), false ) );
+		$old = [[42], 1];
+		$new = [[42, 42, 1], 1];
+		$expected = [new Diff([new DiffOpAdd(1)], false)];
 
-		$argLists[] = array( $old, $new, $expected,
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
 			'Setting a non-default Differ for non-associative diffs should work',
-			true, new ListDiffer( new NativeArrayComparer() ) );
+			true,
+			new ListDiffer(new NativeArrayComparer()),
+		];
 
-		$old = array( 'a' => array( 42 ), 1, array( 'a' => 'b', 5 ), 'bah' => array( 'foo' => 'bar' ) );
-		$new = array( 'a' => array( 42 ), 1, array( 'a' => 'b', 5 ), 'bah' => array( 'foo' => 'baz' ) );
-		$expected = array( 'bah' => new Diff( array( 'foo' => new DiffOpChange( 'bar', 'baz' ) ), true ) );
+		$old = ['a' => [42], 1, ['a' => 'b', 5], 'bah' => ['foo' => 'bar']];
+		$new = ['a' => [42], 1, ['a' => 'b', 5], 'bah' => ['foo' => 'baz']];
+		$expected = ['bah' => new Diff(['foo' => new DiffOpChange('bar', 'baz')], true)];
 
-		$argLists[] = array(
+		$argLists[] = [
 			$old,
 			$new,
 			$expected,
 			'Nested structures with no differences should not result '
-				. 'in nested empty diffs (these empty diffs should be omitted)',
-			true
-		);
+			. 'in nested empty diffs (these empty diffs should be omitted)',
+			true,
+		];
 
-		$old = array( 'links' => array(
-			'enwiki' => array(
-				'page' => 'Foo',
-				'badges' => array(),
-			)
-		) );
-		$new = array( 'links' => array(
-			'enwiki' => array(
-				'page' => 'Foo',
-				'badges' => array(),
-			)
-		) );
-		$expected = array();
+		$old = [
+			'links' => [
+				'enwiki' => [
+					'page' => 'Foo',
+					'badges' => [],
+				],
+			],
+		];
+		$new = [
+			'links' => [
+				'enwiki' => [
+					'page' => 'Foo',
+					'badges' => [],
+				],
+			],
+		];
+		$expected = [];
 
-		$argLists[] = array( $old, $new, $expected,
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
 			'Comparing identical nested structures should not result in diff operations',
-			true );
+			true,
+		];
 
-		$old = array( 'links' => array(
-		) );
-		$new = array( 'links' => array(
-			'enwiki' => array(
-				'page' => 'Foo',
-				'badges' => array(),
-			)
-		) );
-		$expected = array( 'links' => new Diff( array(
-			'enwiki' => new Diff( array(
-				'page' => new DiffOpAdd( 'Foo' )
-			) )
-		), true ) );
+		$old = [
+			'links' => [
+			],
+		];
+		$new = [
+			'links' => [
+				'enwiki' => [
+					'page' => 'Foo',
+					'badges' => [],
+				],
+			],
+		];
+		$expected = [
+			'links' => new Diff(
+				[
+					'enwiki' => new Diff([
+											 'page' => new DiffOpAdd('Foo'),
+										 ]),
+				],
+				true
+			),
+		];
 
-		$argLists[] = array( $old, $new, $expected,
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
 			'Adding a sitelink with no badges',
-			true );
+			true,
+		];
 
-		$old = array( 'links' => array(
-		) );
-		$new = array( 'links' => array(
-			'enwiki' => array(
-				'page' => 'Foo',
-				'badges' => array( 'Bar', 'Baz' ),
-			)
-		) );
-		$expected = array( 'links' => new Diff( array(
-			'enwiki' => new Diff( array(
-				'page' => new DiffOpAdd( 'Foo' ),
-				'badges' => new Diff( array(
-					new DiffOpAdd( 'Bar' ),
-					new DiffOpAdd( 'Baz' ),
-				), false )
-			), true )
-		), true ) );
+		$old = [
+			'links' => [
+			],
+		];
+		$new = [
+			'links' => [
+				'enwiki' => [
+					'page' => 'Foo',
+					'badges' => ['Bar', 'Baz'],
+				],
+			],
+		];
+		$expected = [
+			'links' => new Diff(
+				[
+					'enwiki' => new Diff(
+						[
+							'page' => new DiffOpAdd('Foo'),
+							'badges' => new Diff(
+								[
+									new DiffOpAdd('Bar'),
+									new DiffOpAdd('Baz'),
+								],
+								false
+							),
+						],
+						true
+					),
+				],
+				true
+			),
+		];
 
-		$argLists[] = array( $old, $new, $expected,
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
 			'Adding a sitelink with badges',
-			true );
+			true,
+		];
 
-		$old = array( 'links' => array(
-			'enwiki' => array(
-				'page' => 'Foo',
-				'badges' => array(),
-			)
-		) );
-		$new = array( 'links' => array(
-			'enwiki' => array(
-				'page' => 'Foo',
-				'badges' => array( 'Bar', 'Baz' ),
-			)
-		) );
-		$expected = array( 'links' => new Diff( array(
-			'enwiki' => new Diff( array(
-				'badges' => new Diff( array(
-					new DiffOpAdd( 'Bar' ),
-					new DiffOpAdd( 'Baz' ),
-				), false )
-			), true )
-		), true ) );
+		$old = [
+			'links' => [
+				'enwiki' => [
+					'page' => 'Foo',
+					'badges' => [],
+				],
+			],
+		];
+		$new = [
+			'links' => [
+				'enwiki' => [
+					'page' => 'Foo',
+					'badges' => ['Bar', 'Baz'],
+				],
+			],
+		];
+		$expected = [
+			'links' => new Diff(
+				[
+					'enwiki' => new Diff(
+						[
+							'badges' => new Diff(
+								[
+									new DiffOpAdd('Bar'),
+									new DiffOpAdd('Baz'),
+								],
+								false
+							),
+						], true
+					),
+				],
+				true
+			),
+		];
 
-		$argLists[] = array( $old, $new, $expected,
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
 			'Adding bagdes to a sitelink',
-			true );
+			true,
+		];
 
-		$old = array();
-		$new = array(
-			'enwiki' => array(
+		$old = [];
+		$new = [
+			'enwiki' => [
 				'page' => 'Foo',
-				'badges' => array( 'Bar', 'Baz' ),
-			)
-		);
-		$expected = array(
+				'badges' => ['Bar', 'Baz'],
+			],
+		];
+		$expected = [
 			'enwiki' => new DiffOpAdd(
-				array(
+				[
 					'page' => 'Foo',
-					'badges' => array( 'Bar', 'Baz' ),
-				)
-			)
-		);
+					'badges' => ['Bar', 'Baz'],
+				]
+			),
+		];
 
-		$argLists[] = array( $old, $new, $expected,
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
 			'Adding a sitelink with non-recursive mode',
-			false );
+			false,
+		];
 
-		$old = array(
-			'enwiki' => array(
+		$old = [
+			'enwiki' => [
 				'page' => 'Foo',
-				'badges' => array(),
-			)
-		);
-		$new = array(
-			'enwiki' => array(
+				'badges' => [],
+			],
+		];
+		$new = [
+			'enwiki' => [
 				'page' => 'Foo',
-				'badges' => array( 'Bar', 'Baz' ),
-			)
-		);
-		$expected = array(
+				'badges' => ['Bar', 'Baz'],
+			],
+		];
+		$expected = [
 			'enwiki' => new DiffOpChange(
-				array(
+				[
 					'page' => 'Foo',
-					'badges' => array(),
-				),
-				array(
+					'badges' => [],
+				],
+				[
 					'page' => 'Foo',
-					'badges' => array( 'Bar', 'Baz' ),
-				)
-			)
-		);
+					'badges' => ['Bar', 'Baz'],
+				]
+			),
+		];
 
-		$argLists[] = array( $old, $new, $expected,
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
 			'Adding badges to a sitelink with non-recursive mode',
-			false );
+			false,
+		];
 
 		return $argLists;
 	}
@@ -307,25 +454,32 @@ class MapDifferTest extends DiffTestCase {
 	/**
 	 * @dataProvider toDiffProvider
 	 */
-	public function testDoDiff( $old, $new, $expected, $message = '', $recursively = false, Differ $listDiffer = null ) {
-		$differ = new MapDiffer( $recursively, $listDiffer );
+	public function testDoDiff(
+		$old,
+		$new,
+		$expected,
+		$message = '',
+		$recursively = false,
+		Differ $listDiffer = null
+	): void {
+		$differ = new MapDiffer($recursively, $listDiffer);
 
-		$actual = $differ->doDiff( $old, $new );
+		$actual = $differ->doDiff($old, $new);
 
-		$this->assertArrayEquals( $expected, $actual, false, true, $message );
+		$this->assertArrayEquals($expected, $actual, false, true, $message);
 	}
 
-	public function testCallbackComparisonReturningFalse() {
-		$differ = new MapDiffer( false, null, new StubValueComparer( false ) );
+	public function testCallbackComparisonReturningFalse(): void {
+		$differ = new MapDiffer(false, null, new StubValueComparer(false));
 
-		$actual = $differ->doDiff( array( 1, '2', 3 ), array( 1, '2', 4, 'foo' ) );
+		$actual = $differ->doDiff([1, '2', 3], [1, '2', 4, 'foo']);
 
-		$expected = array(
-			new DiffOpChange( 1, 1 ),
-			new DiffOpChange( '2', '2' ),
-			new DiffOpChange( 3, 4 ),
-			new DiffOpAdd( 'foo' ),
-		);
+		$expected = [
+			new DiffOpChange(1, 1),
+			new DiffOpChange('2', '2'),
+			new DiffOpChange(3, 4),
+			new DiffOpAdd('foo'),
+		];
 
 		$this->assertArrayEquals(
 			$expected, $actual, false, true,
@@ -333,17 +487,17 @@ class MapDifferTest extends DiffTestCase {
 		);
 	}
 
-	public function testCallbackComparisonReturningTrue() {
-		$differ = new MapDiffer( false, null, new StubValueComparer( true ) );
+	public function testCallbackComparisonReturningTrue(): void {
+		$differ = new MapDiffer(false, null, new StubValueComparer(true));
 
-		$actual = $differ->doDiff( array( 1, '2', 'baz' ), array( 1, 'foo', '2' ) );
+		$actual = $differ->doDiff([1, '2', 'baz'], [1, 'foo', '2']);
 
-		$expected = array();
+		$expected = [];
 
 		$this->assertArrayEquals(
 			$expected, $actual, false, true,
 			'No change ops should be created when the arrays have '
-				. 'the same length and the comparison callback always returns true'
+			. 'the same length and the comparison callback always returns true'
 		);
 	}
 

--- a/tests/unit/Differ/OrderedListDifferTest.php
+++ b/tests/unit/Differ/OrderedListDifferTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace Diff\Tests\Differ;
 
@@ -10,210 +10,287 @@ use Diff\Differ\OrderedListDiffer;
 use Diff\DiffOp\DiffOpAdd;
 use Diff\DiffOp\DiffOpRemove;
 use Diff\Tests\DiffTestCase;
+use stdClass;
 
 /**
- * @covers \Diff\Differ\OrderedListDiffer
+ * @covers  \Diff\Differ\OrderedListDiffer
  *
- * @since 0.9
+ * @since   0.9
  *
- * @group Diff
- * @group Differ
+ * @group   Diff
+ * @group   Differ
  *
  * @license BSD-3-Clause
- * @author Jeroen De Dauw < jeroendedauw@gmail.com >
- * @author Tobias Gritschacher < tobias.gritschacher@wikimedia.de >
+ * @author  Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author  Tobias Gritschacher < tobias.gritschacher@wikimedia.de >
  */
 class OrderedListDifferTest extends DiffTestCase {
 
-	/**
-	 * Returns those that both work for native and strict mode.
-	 */
-	private function getCommonArgLists() {
-		$argLists = array();
-
-		$old = array();
-		$new = array();
-		$expected = array();
-
-		$argLists[] = array( $old, $new, $expected,
-			'There should be no difference between empty arrays' );
-
-		$old = array( 42 );
-		$new = array( 42 );
-		$expected = array();
-
-		$argLists[] = array( $old, $new, $expected,
-			'There should be no difference between arrays with the same element' );
-
-		$old = array( 42, 'ohi', 4.2, false );
-		$new = array( 42, 'ohi', 4.2, false );
-		$expected = array();
-
-		$argLists[] = array( $old, $new, $expected,
-			'There should be no difference between arrays with the same elements' );
-
-		$old = array( 42, 'ohi', 4.2, false );
-		$new = array( false, 4.2, 'ohi', 42 );
-		$expected = array(
-			new DiffOpAdd( false ),
-			new DiffOpAdd( 4.2 ),
-			new DiffOpAdd( 'ohi' ),
-			new DiffOpAdd( 42 ),
-			new DiffOpRemove( 42 ),
-			new DiffOpRemove( 'ohi' ),
-			new DiffOpRemove( 4.2 ),
-			new DiffOpRemove( false )
-		);
-
-		$argLists[] = array( $old, $new, $expected,
-			'Changing the order of all four elements should result in four add operations and four remove operations' );
-
-		$old = array( 42, 'ohi', 4.2, false );
-		$new = array( 4.2, 'ohi', 42, false );
-		$expected = array(
-			new DiffOpAdd( 4.2 ),
-			new DiffOpAdd( 42 ),
-			new DiffOpRemove( 42 ),
-			new DiffOpRemove( 4.2 ),
-		);
-
-		$argLists[] = array( $old, $new, $expected,
-			'Changing the order of two of four elements should result in two add operations and two remove operations' );
-
-		$old = array();
-		$new = array( 42 );
-		$expected = array( new DiffOpAdd( 42 ) );
-
-		$argLists[] = array( $old, $new, $expected,
-			'An array with a single element should be an add operation different from an empty array' );
-
-		$old = array( 42 );
-		$new = array();
-		$expected = array( new DiffOpRemove( 42 ) );
-
-		$argLists[] = array( $old, $new, $expected,
-			'An empty array should be a remove operation different from an array with one element' );
-
-		$old = array( 1 );
-		$new = array( 2 );
-		$expected = array( new DiffOpRemove( 1 ), new DiffOpAdd( 2 ) );
-
-		$argLists[] = array( $old, $new, $expected,
-			'Two arrays with a single different element should differ by an add and a remove op' );
-
-		$old = array( 9001, 42, 1, 0 );
-		$new = array( 9001, 42, 2, 0 );
-		$expected = array( new DiffOpRemove( 1 ), new DiffOpAdd( 2 ) );
-
-		$argLists[] = array( $old, $new, $expected,
-			'Two arrays with a single different element should differ by an add and a remove op
-			 when the order of the identical elements stays the same' );
-
-		$old = array( 'a', 'b', 'c' );
-		$new = array( 'c', 'b', 'a', 'd' );
-		$expected = array(
-			new DiffOpRemove( 'a' ),
-			new DiffOpRemove( 'c' ),
-			new DiffOpAdd( 'c' ),
-			new DiffOpAdd( 'a' ),
-			new DiffOpAdd( 'd' )
-		);
-
-		$argLists[] = array( $old, $new, $expected,
-			'Changing the position of two elements and adding one new element should result
-			in two remove ops and three add ops' );
-
-		$old = array( 'a', 'b', 'c', 'd' );
-		$new = array( 'b', 'a', 'c' );
-		$expected = array(
-			new DiffOpRemove( 'a' ),
-			new DiffOpRemove( 'b' ),
-			new DiffOpRemove( 'd' ),
-			new DiffOpAdd( 'b' ),
-			new DiffOpAdd( 'a' )
-		);
-
-		$argLists[] = array( $old, $new, $expected,
-			'Changing the position of two elements and removing the last element should result
-			in three remove ops and two add ops' );
-
-		$old = array( 'a', 'b', 'c' );
-		$new = array( 'b', 'c' );
-		$expected = array(
-			new DiffOpRemove( 'a' ),
-			new DiffOpRemove( 'b' ),
-			new DiffOpRemove( 'c' ),
-			new DiffOpAdd( 'b' ),
-			new DiffOpAdd( 'c' )
-		);
-
-		$argLists[] = array( $old, $new, $expected,
-			'Removing the first element results in remove ops for all elements and add ops for the remaining elements,
-			 because the position of all remaining elements has changed' );
-
-		return $argLists;
-	}
-
-	public function toDiffProvider() {
+	public function toDiffProvider(): array {
 		$argLists = $this->getCommonArgLists();
 
-		$old = array( 42, 42 );
-		$new = array( 42 );
-		$expected = array( new DiffOpRemove( 42 ) );
+		$old = [42, 42];
+		$new = [42];
+		$expected = [new DiffOpRemove(42)];
 
-		$argLists[] = array( $old, $new, $expected,
-			'[42, 42] to [42] should [rem(42)]' );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'[42, 42] to [42] should [rem(42)]',
+		];
 
-		$old = array( 42 );
-		$new = array( 42, 42 );
-		$expected = array( new DiffOpAdd( 42 ) );
+		$old = [42];
+		$new = [42, 42];
+		$expected = [new DiffOpAdd(42)];
 
-		$argLists[] = array( $old, $new, $expected,
-			'[42] to [42, 42] should [add(42)]' );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'[42] to [42, 42] should [add(42)]',
+		];
 
-		$old = array( '42' );
-		$new = array( 42 );
-		$expected = array( new DiffOpRemove( '42' ), new DiffOpAdd( 42 ) );
+		$old = ['42'];
+		$new = [42];
+		$expected = [new DiffOpRemove('42'), new DiffOpAdd(42)];
 
-		$argLists[] = array( $old, $new, $expected,
-			'["42"] to [42] should [rem("42"), add(42)]' );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'["42"] to [42] should [rem("42"), add(42)]',
+		];
 
-		$old = array( array( 1 ) );
-		$new = array( array( 2 ) );
-		$expected = array( new DiffOpRemove( array( 1 ) ), new DiffOpAdd( array( 2 ) ) );
+		$old = [[1]];
+		$new = [[2]];
+		$expected = [new DiffOpRemove([1]), new DiffOpAdd([2])];
 
-		$argLists[] = array( $old, $new, $expected,
-			'[[1]] to [[2]] should [rem([1]), add([2])]' );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'[[1]] to [[2]] should [rem([1]), add([2])]',
+		];
 
-		$old = array( array( 2 ) );
-		$new = array( array( 2 ) );
-		$expected = array();
+		$old = [[2]];
+		$new = [[2]];
+		$expected = [];
 
-		$argLists[] = array( $old, $new, $expected,
-			'[[2]] to [[2]] should result in an empty diff' );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'[[2]] to [[2]] should result in an empty diff',
+		];
 
 		// test "soft" object comparison
-		$obj1 = new \stdClass();
-		$obj2 = new \stdClass();
-		$objX = new \stdClass();
+		$obj1 = new stdClass();
+		$obj2 = new stdClass();
+		$objX = new stdClass();
 
 		$obj1->test = 'Test';
 		$obj2->test = 'Test';
 		$objX->xest = 'Test';
 
-		$old = array( $obj1 );
-		$new = array( $obj2 );
-		$expected = array( );
+		$old = [$obj1];
+		$new = [$obj2];
+		$expected = [];
 
-		$argLists[] = array( $old, $new, $expected,
-			'Two arrays containing equivalent objects should result in an empty diff' );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'Two arrays containing equivalent objects should result in an empty diff',
+		];
 
-		$old = array( $obj1 );
-		$new = array( $objX );
-		$expected = array( new DiffOpRemove( $obj1 ), new DiffOpAdd( $objX )  );
+		$old = [$obj1];
+		$new = [$objX];
+		$expected = [new DiffOpRemove($obj1), new DiffOpAdd($objX)];
 
-		$argLists[] = array( $old, $new, $expected,
-			'Two arrays containing different objects of the same type should result in an add and a remove op.' );
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'Two arrays containing different objects of the same type should result in an add and a remove op.',
+		];
+
+		return $argLists;
+	}
+
+	/**
+	 * Returns those that both work for native and strict mode.
+	 */
+	private function getCommonArgLists(): array {
+		$argLists = [];
+
+		$old = [];
+		$new = [];
+		$expected = [];
+
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'There should be no difference between empty arrays',
+		];
+
+		$old = [42];
+		$new = [42];
+		$expected = [];
+
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'There should be no difference between arrays with the same element',
+		];
+
+		$old = [42, 'ohi', 4.2, false];
+		$new = [42, 'ohi', 4.2, false];
+		$expected = [];
+
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'There should be no difference between arrays with the same elements',
+		];
+
+		$old = [42, 'ohi', 4.2, false];
+		$new = [false, 4.2, 'ohi', 42];
+		$expected = [
+			new DiffOpAdd(false),
+			new DiffOpAdd(4.2),
+			new DiffOpAdd('ohi'),
+			new DiffOpAdd(42),
+			new DiffOpRemove(42),
+			new DiffOpRemove('ohi'),
+			new DiffOpRemove(4.2),
+			new DiffOpRemove(false),
+		];
+
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'Changing the order of all four elements should result in four add operations and four remove operations',
+		];
+
+		$old = [42, 'ohi', 4.2, false];
+		$new = [4.2, 'ohi', 42, false];
+		$expected = [
+			new DiffOpAdd(4.2),
+			new DiffOpAdd(42),
+			new DiffOpRemove(42),
+			new DiffOpRemove(4.2),
+		];
+
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'Changing the order of two of four elements should result in two add operations and two remove operations',
+		];
+
+		$old = [];
+		$new = [42];
+		$expected = [new DiffOpAdd(42)];
+
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'An array with a single element should be an add operation different from an empty array',
+		];
+
+		$old = [42];
+		$new = [];
+		$expected = [new DiffOpRemove(42)];
+
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'An empty array should be a remove operation different from an array with one element',
+		];
+
+		$old = [1];
+		$new = [2];
+		$expected = [new DiffOpRemove(1), new DiffOpAdd(2)];
+
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'Two arrays with a single different element should differ by an add and a remove op',
+		];
+
+		$old = [9001, 42, 1, 0];
+		$new = [9001, 42, 2, 0];
+		$expected = [new DiffOpRemove(1), new DiffOpAdd(2)];
+
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'Two arrays with a single different element should differ by an add and a remove op
+			 when the order of the identical elements stays the same',
+		];
+
+		$old = ['a', 'b', 'c'];
+		$new = ['c', 'b', 'a', 'd'];
+		$expected = [
+			new DiffOpRemove('a'),
+			new DiffOpRemove('c'),
+			new DiffOpAdd('c'),
+			new DiffOpAdd('a'),
+			new DiffOpAdd('d'),
+		];
+
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'Changing the position of two elements and adding one new element should result
+			in two remove ops and three add ops',
+		];
+
+		$old = ['a', 'b', 'c', 'd'];
+		$new = ['b', 'a', 'c'];
+		$expected = [
+			new DiffOpRemove('a'),
+			new DiffOpRemove('b'),
+			new DiffOpRemove('d'),
+			new DiffOpAdd('b'),
+			new DiffOpAdd('a'),
+		];
+
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'Changing the position of two elements and removing the last element should result
+			in three remove ops and two add ops',
+		];
+
+		$old = ['a', 'b', 'c'];
+		$new = ['b', 'c'];
+		$expected = [
+			new DiffOpRemove('a'),
+			new DiffOpRemove('b'),
+			new DiffOpRemove('c'),
+			new DiffOpAdd('b'),
+			new DiffOpAdd('c'),
+		];
+
+		$argLists[] = [
+			$old,
+			$new,
+			$expected,
+			'Removing the first element results in remove ops for all elements and add ops for the remaining elements,
+			 because the position of all remaining elements has changed',
+		];
 
 		return $argLists;
 	}
@@ -221,13 +298,13 @@ class OrderedListDifferTest extends DiffTestCase {
 	/**
 	 * @dataProvider toDiffProvider
 	 */
-	public function testDoDiff( $old, $new, $expected, $message = '' ) {
-		$callback = function( $foo, $bar ) {
-			return is_object( $foo ) ? $foo == $bar : $foo === $bar;
+	public function testDoDiff($old, $new, $expected, $message = ''): void {
+		$callback = function ($foo, $bar) {
+			return is_object($foo) ? $foo == $bar : $foo === $bar;
 		};
 
 		$this->doTestDiff(
-			new OrderedListDiffer( new CallbackComparer( $callback ) ),
+			new OrderedListDiffer(new CallbackComparer($callback)),
 			$old,
 			$new,
 			$expected,
@@ -235,26 +312,28 @@ class OrderedListDifferTest extends DiffTestCase {
 		);
 	}
 
-	private function doTestDiff( Differ $differ, $old, $new, $expected, $message ) {
-		$actual = $differ->doDiff( $old, $new );
+	private function doTestDiff(Differ $differ, $old, $new, $expected, $message): void {
+		$actual = $differ->doDiff($old, $new);
 
-		$this->assertArrayEquals( $expected, $actual, false, false, $message );
+		$this->assertArrayEquals($expected, $actual, false, false, $message);
 	}
 
-	public function testCallbackComparisonReturningFalse() {
-		$differ = new OrderedListDiffer( new CallbackComparer( function() {
-			return false;
-		} ) );
-
-		$actual = $differ->doDiff( array( 1, '2' ), array( 1, '2', 'foo' ) );
-
-		$expected = array(
-			new DiffOpAdd( 1 ),
-			new DiffOpAdd( '2' ),
-			new DiffOpAdd( 'foo' ),
-			new DiffOpRemove( 1 ),
-			new DiffOpRemove( '2' ),
+	public function testCallbackComparisonReturningFalse(): void {
+		$differ = new OrderedListDiffer(
+			new CallbackComparer(function () {
+				return false;
+			})
 		);
+
+		$actual = $differ->doDiff([1, '2'], [1, '2', 'foo']);
+
+		$expected = [
+			new DiffOpAdd(1),
+			new DiffOpAdd('2'),
+			new DiffOpAdd('foo'),
+			new DiffOpRemove(1),
+			new DiffOpRemove('2'),
+		];
 
 		$this->assertArrayEquals(
 			$expected, $actual, false, false,
@@ -262,14 +341,16 @@ class OrderedListDifferTest extends DiffTestCase {
 		);
 	}
 
-	public function testCallbackComparisonReturningTrue() {
-		$differ = new OrderedListDiffer( new CallbackComparer( function() {
-			return true;
-		} ) );
+	public function testCallbackComparisonReturningTrue(): void {
+		$differ = new OrderedListDiffer(
+			new CallbackComparer(function () {
+				return true;
+			})
+		);
 
-		$actual = $differ->doDiff( array( 1, '2', 'baz' ), array( 1, 'foo', '2' ) );
+		$actual = $differ->doDiff([1, '2', 'baz'], [1, 'foo', '2']);
 
-		$expected = array();
+		$expected = [];
 
 		$this->assertArrayEquals(
 			$expected, $actual, false, false,
@@ -277,14 +358,16 @@ class OrderedListDifferTest extends DiffTestCase {
 		);
 	}
 
-	public function testCallbackComparisonReturningNyanCat() {
-		$differ = new OrderedListDiffer( new CallbackComparer( function() {
-			return '~=[,,_,,]:3';
-		} ) );
+	public function testCallbackComparisonReturningNyanCat(): void {
+		$differ = new OrderedListDiffer(
+			new CallbackComparer(function () {
+				return '~=[,,_,,]:3';
+			})
+		);
 
-		$this->expectException( 'RuntimeException' );
+		$this->expectException('RuntimeException');
 
-		$differ->doDiff( array( 1, '2', 'baz' ), array( 1, 'foo', '2' ) );
+		$differ->doDiff([1, '2', 'baz'], [1, 'foo', '2']);
 	}
 
 }

--- a/tests/unit/Fixtures/StubComparable.php
+++ b/tests/unit/Fixtures/StubComparable.php
@@ -1,24 +1,24 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace Diff\Tests\Fixtures;
 
 /**
  * @license BSD-3-Clause
- * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author  Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class StubComparable {
 
 	private $field;
 
-	public function __construct( $field ) {
+	public function __construct($field) {
 		$this->field = $field;
 	}
 
-	public function equals( $otherComparable ) {
+	public function equals($otherComparable) {
 		return $otherComparable instanceof StubComparable
-		&& $otherComparable->getField() === $this->field;
+			&& $otherComparable->getField() === $this->field;
 	}
 
 	public function getField() {

--- a/tests/unit/Fixtures/StubValueComparer.php
+++ b/tests/unit/Fixtures/StubValueComparer.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace Diff\Tests\Fixtures;
 
@@ -8,20 +8,21 @@ use Diff\Comparer\ValueComparer;
 
 /**
  * @license BSD-3-Clause
- * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author  Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class StubValueComparer implements ValueComparer {
 
-	private $returnValue;
+	private bool $returnValue;
 
-	public function __construct( bool $returnValue ) {
+	public function __construct(bool $returnValue) {
 		$this->returnValue = $returnValue;
 	}
 
-	// @codingStandardsIgnoreStart
-	public function valuesAreEqual( $firstValue, $secondValue ): bool {
-		// @codingStandardsIgnoreEnd
+    // @codingStandardsIgnoreStart
+    public function valuesAreEqual($firstValue, $secondValue): bool
+    {
 		return $this->returnValue;
 	}
+    // @codingStandardsIgnoreEnd
 
 }

--- a/tests/unit/Patcher/ListPatcherTest.php
+++ b/tests/unit/Patcher/ListPatcherTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace Diff\Tests\Patcher;
 
@@ -13,104 +13,117 @@ use Diff\Tests\DiffTestCase;
 use stdClass;
 
 /**
- * @covers \Diff\Patcher\ListPatcher
- * @covers \Diff\Patcher\ThrowingPatcher
+ * @covers  \Diff\Patcher\ListPatcher
+ * @covers  \Diff\Patcher\ThrowingPatcher
  *
- * @group Diff
- * @group DiffPatcher
+ * @group   Diff
+ * @group   DiffPatcher
  *
  * @license BSD-3-Clause
- * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author  Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class ListPatcherTest extends DiffTestCase {
 
-	public function patchProvider() {
-		$argLists = array();
+	public function patchProvider(): array {
+		$argLists = [];
 
 		$patcher = new ListPatcher();
-		$base = array();
+		$base = [];
 		$diff = new Diff();
-		$expected = array();
+		$expected = [];
 
-		$argLists[] = array( $patcher, $base, $diff, $expected );
+		$argLists[] = [$patcher, $base, $diff, $expected];
 
 		$patcher = new ListPatcher();
-		$base = array( 4, 2 );
+		$base = [4, 2];
 		$diff = new Diff();
-		$expected = array( 4, 2 );
+		$expected = [4, 2];
 
-		$argLists[] = array( $patcher, $base, $diff, $expected );
-
-		$patcher = new ListPatcher();
-		$base = array();
-		$diff = new Diff( array(
-			new DiffOpAdd( 9001 )
-		) );
-		$expected = array( 9001 );
-
-		$argLists[] = array( $patcher, $base, $diff, $expected );
+		$argLists[] = [$patcher, $base, $diff, $expected];
 
 		$patcher = new ListPatcher();
-		$base = array( 4, 2 );
-		$diff = new Diff( array(
-			new DiffOpAdd( 9001 )
-		) );
-		$expected = array( 4, 2, 9001 );
-
-		$argLists[] = array( $patcher, $base, $diff, $expected );
-
-		$patcher = new ListPatcher();
-		$base = array( 4, 2 );
-		$diff = new Diff( array(
-			new DiffOpAdd( 9001 ),
-			new DiffOpAdd( 9002 ),
-			new DiffOpAdd( 2 )
-		) );
-		$expected = array( 4, 2, 9001, 9002, 2 );
-
-		$argLists[] = array( $patcher, $base, $diff, $expected );
-
-		$patcher = new ListPatcher();
-		$base = array( 0, 1, 2, 3, 4 );
-		$diff = new Diff( array(
-			new DiffOpRemove( 2 ),
-			new DiffOpRemove( 3 ),
-		) );
-		$expected = array( 0, 1, 4 );
-
-		$argLists[] = array( $patcher, $base, $diff, $expected );
-
-		$patcher = new ListPatcher();
-		$base = array( 0, 1, 2, 2, 2, 3, 4 );
-		$diff = new Diff( array(
-			new DiffOpRemove( 2 ),
-			new DiffOpRemove( 3 ),
-			new DiffOpAdd( 6 ),
-			new DiffOpRemove( 2 ),
-		) );
-		$expected = array( 0, 1, 2, 4, 6 );
-
-		$argLists[] = array( $patcher, $base, $diff, $expected );
-
-		$patcher = new ListPatcher();
-		$base = array(
-			$this->newObject( 'foo' ),
-			$this->newObject( 'bar' ),
+		$base = [];
+		$diff = new Diff(
+			[
+				new DiffOpAdd(9001),
+			]
 		);
-		$diff = new Diff( array(
-			new DiffOpRemove( $this->newObject( 'foo' ) ),
-			new DiffOpAdd( $this->newObject( 'baz' ) ),
-		) );
-		$expected = array( $this->newObject( 'bar' ), $this->newObject( 'baz' ) );
+		$expected = [9001];
 
-		$argLists[] = array( $patcher, $base, $diff, $expected );
+		$argLists[] = [$patcher, $base, $diff, $expected];
+
+		$patcher = new ListPatcher();
+		$base = [4, 2];
+		$diff = new Diff(
+			[
+				new DiffOpAdd(9001),
+			]
+		);
+		$expected = [4, 2, 9001];
+
+		$argLists[] = [$patcher, $base, $diff, $expected];
+
+		$patcher = new ListPatcher();
+		$base = [4, 2];
+		$diff = new Diff(
+			[
+				new DiffOpAdd(9001),
+				new DiffOpAdd(9002),
+				new DiffOpAdd(2),
+			]
+		);
+		$expected = [4, 2, 9001, 9002, 2];
+
+		$argLists[] = [$patcher, $base, $diff, $expected];
+
+		$patcher = new ListPatcher();
+		$base = [0, 1, 2, 3, 4];
+		$diff = new Diff(
+			[
+				new DiffOpRemove(2),
+				new DiffOpRemove(3),
+			]
+		);
+		$expected = [0, 1, 4];
+
+		$argLists[] = [$patcher, $base, $diff, $expected];
+
+		$patcher = new ListPatcher();
+		$base = [0, 1, 2, 2, 2, 3, 4];
+		$diff = new Diff(
+			[
+				new DiffOpRemove(2),
+				new DiffOpRemove(3),
+				new DiffOpAdd(6),
+				new DiffOpRemove(2),
+			]
+		);
+		$expected = [0, 1, 2, 4, 6];
+
+		$argLists[] = [$patcher, $base, $diff, $expected];
+
+		$patcher = new ListPatcher();
+		$base = [
+			$this->newObject('foo'),
+			$this->newObject('bar'),
+		];
+		$diff = new Diff(
+			[
+				new DiffOpRemove($this->newObject('foo')),
+				new DiffOpAdd($this->newObject('baz')),
+			]
+		);
+		$expected = [$this->newObject('bar'), $this->newObject('baz')];
+
+		$argLists[] = [$patcher, $base, $diff, $expected];
 
 		return $argLists;
 	}
 
-	private function newObject( $value ) : stdClass {
+	private function newObject($value): stdClass {
 		$object = new stdClass();
 		$object->element = $value;
+
 		return $object;
 	}
 
@@ -118,130 +131,151 @@ class ListPatcherTest extends DiffTestCase {
 	 * @dataProvider patchProvider
 	 *
 	 * @param Patcher $patcher
-	 * @param array $base
-	 * @param Diff $diff
-	 * @param array $expected
+	 * @param array   $base
+	 * @param Diff    $diff
+	 * @param array   $expected
 	 */
-	public function testPatch( Patcher $patcher, array $base, Diff $diff, array $expected ) {
-		$actual = $patcher->patch( $base, $diff );
+	public function testPatch(Patcher $patcher, array $base, Diff $diff, array $expected) {
+		$actual = $patcher->patch($base, $diff);
 
-		$this->assertArrayEquals( $expected, $actual );
+		$this->assertArrayEquals($expected, $actual);
 	}
 
 	/**
 	 * @dataProvider getApplicableDiffProvider
 	 *
-	 * @param Diff $diff
-	 * @param array $currentObject
-	 * @param Diff $expected
+	 * @param Diff        $diff
+	 * @param array       $currentObject
+	 * @param Diff        $expected
 	 * @param string|null $message
 	 */
-	public function testGetApplicableDiff( Diff $diff, array $currentObject, Diff $expected, $message = null ) {
+	public function testGetApplicableDiff(Diff $diff, array $currentObject, Diff $expected, $message = null) {
 		$patcher = new ListPatcher();
-		$actual = $patcher->getApplicableDiff( $currentObject, $diff );
+		$actual = $patcher->getApplicableDiff($currentObject, $diff);
 
-		$this->assertEquals( $expected->getOperations(), $actual->getOperations(), $message );
+		$this->assertEquals($expected->getOperations(), $actual->getOperations(), $message);
 	}
 
 	public function getApplicableDiffProvider() {
 		// Diff, current object, expected
-		$argLists = array();
+		$argLists = [];
 
-		$diff = new Diff( array(), false );
-		$currentObject = array();
+		$diff = new Diff([], false);
+		$currentObject = [];
 		$expected = clone $diff;
 
-		$argLists[] = array( $diff, $currentObject, $expected, 'Empty diff should remain empty on empty base' );
+		$argLists[] = [$diff, $currentObject, $expected, 'Empty diff should remain empty on empty base'];
 
-		$diff = new Diff( array(), false );
+		$diff = new Diff([], false);
 
-		$currentObject = array( 'foo' => 0, 'bar' => 1 );
-
-		$expected = clone $diff;
-
-		$argLists[] = array( $diff, $currentObject, $expected, 'Empty diff should remain empty on non-empty base' );
-
-		$diff = new Diff( array(
-			new DiffOpRemove( 9001 ),
-		), false );
-
-		$currentObject = array();
-
-		$expected = new Diff( array(), false );
-
-		$argLists[] = array( $diff, $currentObject, $expected, 'Remove ops should be removed on empty base' );
-
-		$diff = new Diff( array(
-			new DiffOpAdd( 42 ),
-			new DiffOpRemove( 9001 ),
-		), false );
-
-		$currentObject = array();
-
-		$expected = new Diff( array(
-			new DiffOpAdd( 42 ),
-		), true );
-
-		$argLists[] = array(
-			$diff,
-			$currentObject,
-			$expected,
-			'Add ops not present in the base should be retained (ListDiff)'
-		);
-
-		$diff = new Diff( array(
-			new DiffOpAdd( 42 ),
-			new DiffOpRemove( 9001 ),
-		), false );
-
-		$currentObject = array( 1, 42, 9001 );
-
-		$expected = new Diff( array(
-			new DiffOpAdd( 42 ),
-			new DiffOpRemove( 9001 ),
-		), false );
-
-		$argLists[] = array(
-			$diff,
-			$currentObject,
-			$expected,
-			'Add ops with values present in the base should be retained in ListDiff'
-		);
-
-		$diff = new Diff( array(
-			new DiffOpAdd( 42 ),
-		), false );
-
-		$currentObject = array();
+		$currentObject = ['foo' => 0, 'bar' => 1];
 
 		$expected = clone $diff;
 
-		$argLists[] = array(
+		$argLists[] = [$diff, $currentObject, $expected, 'Empty diff should remain empty on non-empty base'];
+
+		$diff = new Diff(
+			[
+				new DiffOpRemove(9001),
+			],
+			false
+		);
+
+		$currentObject = [];
+
+		$expected = new Diff([], false);
+
+		$argLists[] = [$diff, $currentObject, $expected, 'Remove ops should be removed on empty base'];
+
+		$diff = new Diff(
+			[
+				new DiffOpAdd(42),
+				new DiffOpRemove(9001),
+			],
+			false
+		);
+
+		$currentObject = [];
+
+		$expected = new Diff(
+			[
+				new DiffOpAdd(42),
+			],
+			true
+		);
+
+		$argLists[] = [
 			$diff,
 			$currentObject,
 			$expected,
-			'list diffs containing only add ops should be retained even when not in the base'
+			'Add ops not present in the base should be retained (ListDiff)',
+		];
+
+		$diff = new Diff(
+			[
+				new DiffOpAdd(42),
+				new DiffOpRemove(9001),
+			],
+			false
 		);
 
-		$diff = new Diff( array(
-			new DiffOpRemove( 42 ),
-			new DiffOpRemove( 9001 ),
-		), false );
+		$currentObject = [1, 42, 9001];
 
-		$currentObject = array(
+		$expected = new Diff(
+			[
+				new DiffOpAdd(42),
+				new DiffOpRemove(9001),
+			],
+			false
+		);
+
+		$argLists[] = [
+			$diff,
+			$currentObject,
+			$expected,
+			'Add ops with values present in the base should be retained in ListDiff',
+		];
+
+		$diff = new Diff(
+			[
+				new DiffOpAdd(42),
+			],
+			false
+		);
+
+		$currentObject = [];
+
+		$expected = clone $diff;
+
+		$argLists[] = [
+			$diff,
+			$currentObject,
+			$expected,
+			'list diffs containing only add ops should be retained even when not in the base',
+		];
+
+		$diff = new Diff(
+			[
+				new DiffOpRemove(42),
+				new DiffOpRemove(9001),
+			],
+			false
+		);
+
+		$currentObject = [
 			42,
 			72010,
 			9001,
-		);
+		];
 
 		$expected = clone $diff;
 
-		$argLists[] = array(
+		$argLists[] = [
 			$diff,
 			$currentObject,
 			$expected,
-			'list diffs containing only remove ops should be retained when present in the base'
-		);
+			'list diffs containing only remove ops should be retained when present in the base',
+		];
 
 		return $argLists;
 	}
@@ -249,12 +283,12 @@ class ListPatcherTest extends DiffTestCase {
 	public function testPatchMapRaisesError() {
 		$patcher = new ListPatcher();
 
-		$patcher->patch( array(), new Diff( array(), true ) );
+		$patcher->patch([], new Diff([], true));
 
 		$patcher->throwErrors();
-		$this->expectException( 'Diff\Patcher\PatcherException' );
+		$this->expectException('Diff\Patcher\PatcherException');
 
-		$patcher->patch( array(), new Diff( array(), true ) );
+		$patcher->patch([], new Diff([], true));
 	}
 
 }

--- a/tests/unit/Patcher/MapPatcherTest.php
+++ b/tests/unit/Patcher/MapPatcherTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace Diff\Tests\Patcher;
 
@@ -14,202 +14,229 @@ use Diff\Patcher\Patcher;
 use Diff\Tests\DiffTestCase;
 
 /**
- * @covers \Diff\Patcher\MapPatcher
- * @covers \Diff\Patcher\ThrowingPatcher
+ * @covers  \Diff\Patcher\MapPatcher
+ * @covers  \Diff\Patcher\ThrowingPatcher
  *
- * @group Diff
- * @group DiffPatcher
+ * @group   Diff
+ * @group   DiffPatcher
  *
  * @license BSD-3-Clause
- * @author Jeroen De Dauw < jeroendedauw@gmail.com >
- * @author Daniel Kinzler
+ * @author  Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author  Daniel Kinzler
  */
 class MapPatcherTest extends DiffTestCase {
 
-	public function patchProvider() {
-		$argLists = array();
+	public function patchProvider(): array {
+		$argLists = [];
 
 		$patcher = new MapPatcher();
-		$base = array();
+		$base = [];
 		$diff = new Diff();
-		$expected = array();
+		$expected = [];
 
-		$argLists['all empty'] = array( $patcher, $base, $diff, $expected );
+		$argLists['all empty'] = [$patcher, $base, $diff, $expected];
 
 		$patcher = new MapPatcher();
-		$base = array( 'foo', 'bar' => array( 'baz' ) );
+		$base = ['foo', 'bar' => ['baz']];
 		$diff = new Diff();
-		$expected = array( 'foo', 'bar' => array( 'baz' ) );
+		$expected = ['foo', 'bar' => ['baz']];
 
-		$argLists['empty patch'] = array( $patcher, $base, $diff, $expected );
-
-		$patcher = new MapPatcher();
-		$base = array( 'foo', 'bar' => array( 'baz' ) );
-		$diff = new Diff( array( 'bah' => new DiffOpAdd( 'blah' ) ) );
-		$expected = array( 'foo', 'bar' => array( 'baz' ), 'bah' => 'blah' );
-
-		$argLists['add'] = array( $patcher, $base, $diff, $expected );
+		$argLists['empty patch'] = [$patcher, $base, $diff, $expected];
 
 		$patcher = new MapPatcher();
-		$base = array( 'foo', 'bar' => array( 'baz' ) );
-		$diff = new Diff( array( 'bah' => new DiffOpAdd( 'blah' ) ) );
-		$expected = array( 'foo', 'bar' => array( 'baz' ), 'bah' => 'blah' );
+		$base = ['foo', 'bar' => ['baz']];
+		$diff = new Diff(['bah' => new DiffOpAdd('blah')]);
+		$expected = ['foo', 'bar' => ['baz'], 'bah' => 'blah'];
 
-		$argLists['add2'] = array( $patcher, $base, $diff, $expected ); //FIXME: dupe?
+		$argLists['add'] = [$patcher, $base, $diff, $expected];
 
 		$patcher = new MapPatcher();
-		$base = array();
-		$diff = new Diff( array(
-			'foo' => new DiffOpAdd( 'bar' ),
-			'bah' => new DiffOpAdd( 'blah' )
-		) );
-		$expected = array(
+		$base = ['foo', 'bar' => ['baz']];
+		$diff = new Diff(['bah' => new DiffOpAdd('blah')]);
+		$expected = ['foo', 'bar' => ['baz'], 'bah' => 'blah'];
+
+		$argLists['add2'] = [$patcher, $base, $diff, $expected]; //FIXME: dupe?
+
+		$patcher = new MapPatcher();
+		$base = [];
+		$diff = new Diff(
+			[
+				'foo' => new DiffOpAdd('bar'),
+				'bah' => new DiffOpAdd('blah'),
+			]
+		);
+		$expected = [
 			'foo' => 'bar',
-			'bah' => 'blah'
-		);
+			'bah' => 'blah',
+		];
 
-		$argLists['add to empty base'] = array( $patcher, $base, $diff, $expected );
-
-		$patcher = new MapPatcher();
-		$base = array(
-			'enwiki' => array(
-				'name'   => 'Nyan Cat',
-				'badges' => array( 'FA' )
-			)
-		);
-		$diff = new Diff( array(
-			'nlwiki' => new Diff( array(
-				'name'   => new DiffOpAdd( 'Nyan Cat' ),
-				'badges' => new Diff( array(
-					new DiffOpAdd( 'J approves' ),
-				), false ),
-			), true ),
-		), true );
-		$expected = array(
-			'enwiki' => array(
-				'name'   => 'Nyan Cat',
-				'badges' => array( 'FA' )
-			),
-
-			'nlwiki' => array(
-				'name'   => 'Nyan Cat',
-				'badges' => array( 'J approves' )
-			)
-		);
-
-		$argLists['add to non-existent key'] = array( $patcher, $base, $diff, $expected );
+		$argLists['add to empty base'] = [$patcher, $base, $diff, $expected];
 
 		$patcher = new MapPatcher();
-		$base = array(
+		$base = [
+			'enwiki' => [
+				'name' => 'Nyan Cat',
+				'badges' => ['FA'],
+			],
+		];
+		$diff = new Diff(
+			[
+				'nlwiki' => new Diff(
+					[
+						'name' => new DiffOpAdd('Nyan Cat'),
+						'badges' => new Diff(
+							[
+								new DiffOpAdd('J approves'),
+							],
+							false
+						),
+					],
+					true
+				),
+			],
+			true
+		);
+		$expected = [
+			'enwiki' => [
+				'name' => 'Nyan Cat',
+				'badges' => ['FA'],
+			],
+
+			'nlwiki' => [
+				'name' => 'Nyan Cat',
+				'badges' => ['J approves'],
+			],
+		];
+
+		$argLists['add to non-existent key'] = [$patcher, $base, $diff, $expected];
+
+		$patcher = new MapPatcher();
+		$base = [
 			'foo' => 'bar',
 			'nyan' => 'cat',
 			'bah' => 'blah',
+		];
+		$diff = new Diff(
+			[
+				'foo' => new DiffOpRemove('bar'),
+				'bah' => new DiffOpRemove('blah'),
+			]
 		);
-		$diff = new Diff( array(
-			'foo' => new DiffOpRemove( 'bar' ),
-			'bah' => new DiffOpRemove( 'blah' ),
-		) );
-		$expected = array(
-			'nyan' => 'cat'
-		);
+		$expected = [
+			'nyan' => 'cat',
+		];
 
-		$argLists['remove'] = array( $patcher, $base, $diff, $expected );
+		$argLists['remove'] = [$patcher, $base, $diff, $expected];
 
 		$patcher = new MapPatcher();
-		$base = array(
+		$base = [
 			'foo' => 'bar',
 			'nyan' => 'cat',
 			'spam' => 'blah',
 			'bah' => 'blah',
+		];
+		$diff = new Diff(
+			[
+				'foo' => new DiffOpChange('bar', 'baz'),
+				'bah' => new DiffOpRemove('blah'),
+				'oh' => new DiffOpAdd('noez'),
+			]
 		);
-		$diff = new Diff( array(
-			'foo' => new DiffOpChange( 'bar', 'baz' ),
-			'bah' => new DiffOpRemove( 'blah' ),
-			'oh' => new DiffOpAdd( 'noez' ),
-		) );
-		$expected = array(
+		$expected = [
 			'foo' => 'baz',
 			'nyan' => 'cat',
 			'spam' => 'blah',
 			'oh' => 'noez',
-		);
+		];
 
-		$argLists['change/add/remove'] = array( $patcher, $base, $diff, $expected );
+		$argLists['change/add/remove'] = [$patcher, $base, $diff, $expected];
 
 		$patcher = new MapPatcher();
-		$base = array(
+		$base = [
 			'foo' => 'bar',
+		];
+		$diff = new Diff(
+			[
+				'baz' => new Diff([new DiffOpAdd('ny'), new DiffOpAdd('an')], false),
+			]
 		);
-		$diff = new Diff( array(
-			'baz' => new Diff( array( new DiffOpAdd( 'ny' ), new DiffOpAdd( 'an' ) ), false ),
-		) );
-		$expected = array(
+		$expected = [
 			'foo' => 'bar',
-			'baz' => array( 'ny', 'an' ),
-		);
+			'baz' => ['ny', 'an'],
+		];
 
-		$argLists['add to substructure'] = array( $patcher, $base, $diff, $expected );
+		$argLists['add to substructure'] = [$patcher, $base, $diff, $expected];
 
 		// ---- conflicts ----
 
 		$patcher = new MapPatcher();
-		$base = array();
-		$diff = new Diff( array(
-			'baz' => new DiffOpRemove( 'X' ),
-		) );
+		$base = [];
+		$diff = new Diff(
+			[
+				'baz' => new DiffOpRemove('X'),
+			]
+		);
 		$expected = $base;
 
-		$argLists['conflict: remove missing'] = array( $patcher, $base, $diff, $expected );
+		$argLists['conflict: remove missing'] = [$patcher, $base, $diff, $expected];
 
 		$patcher = new MapPatcher();
-		$base = array( 'baz' => 'Y' );
-		$diff = new Diff( array(
-			'baz' => new DiffOpRemove( 'X' ),
-		) );
+		$base = ['baz' => 'Y'];
+		$diff = new Diff(
+			[
+				'baz' => new DiffOpRemove('X'),
+			]
+		);
 		$expected = $base;
 
-		$argLists['conflict: remove mismatching value'] = array( $patcher, $base, $diff, $expected );
+		$argLists['conflict: remove mismatching value'] = [$patcher, $base, $diff, $expected];
 
 		$patcher = new MapPatcher();
-		$base = array( 'baz' => 'Y' );
-		$diff = new Diff( array(
-			'baz' => new DiffOpAdd( 'X' ),
-		) );
+		$base = ['baz' => 'Y'];
+		$diff = new Diff(
+			[
+				'baz' => new DiffOpAdd('X'),
+			]
+		);
 		$expected = $base;
 
-		$argLists['conflict: add existing'] = array( $patcher, $base, $diff, $expected );
+		$argLists['conflict: add existing'] = [$patcher, $base, $diff, $expected];
 
 		$patcher = new MapPatcher();
-		$base = array( 'baz' => 'Y' );
-		$diff = new Diff( array(
-			'baz' => new DiffOpChange( 'X', 'Z' ),
-		) );
+		$base = ['baz' => 'Y'];
+		$diff = new Diff(
+			[
+				'baz' => new DiffOpChange('X', 'Z'),
+			]
+		);
 		$expected = $base;
 
-		$argLists['conflict: change mismatching value'] = array( $patcher, $base, $diff, $expected );
+		$argLists['conflict: change mismatching value'] = [$patcher, $base, $diff, $expected];
 
 		$patcher = new MapPatcher();
-		$base = array(
+		$base = [
 			'foo' => 'bar',
 			'nyan' => 'cat',
 			'spam' => 'blah',
 			'bah' => 'blah',
+		];
+		$diff = new Diff(
+			[
+				'foo' => new DiffOpChange('bar', 'var'),
+				'nyan' => new DiffOpRemove('fat'),
+				'bah' => new DiffOpChange('blubb', 'clubb'),
+				'yea' => new DiffOpAdd('stuff'),
+			]
 		);
-		$diff = new Diff( array(
-			'foo' => new DiffOpChange( 'bar', 'var' ),
-			'nyan' => new DiffOpRemove( 'fat' ),
-			'bah' => new DiffOpChange( 'blubb', 'clubb' ),
-			'yea' => new DiffOpAdd( 'stuff' ),
-		) );
-		$expected = array(
+		$expected = [
 			'foo' => 'var',
 			'nyan' => 'cat',
 			'spam' => 'blah',
 			'bah' => 'blah',
 			'yea' => 'stuff',
-		);
+		];
 
-		$argLists['some mixed conflicts'] = array( $patcher, $base, $diff, $expected );
+		$argLists['some mixed conflicts'] = [$patcher, $base, $diff, $expected];
 
 		return $argLists;
 	}
@@ -218,144 +245,180 @@ class MapPatcherTest extends DiffTestCase {
 	 * @dataProvider patchProvider
 	 *
 	 * @param Patcher $patcher
-	 * @param array $base
-	 * @param Diff $diff
-	 * @param array $expected
+	 * @param array   $base
+	 * @param Diff    $diff
+	 * @param array   $expected
 	 */
-	public function testPatch( Patcher $patcher, array $base, Diff $diff, array $expected ) {
-		$actual = $patcher->patch( $base, $diff );
+	public function testPatch(Patcher $patcher, array $base, Diff $diff, array $expected): void {
+		$actual = $patcher->patch($base, $diff);
 
-		$this->assertArrayEquals( $expected, $actual, true, true );
+		$this->assertArrayEquals($expected, $actual, true, true);
 	}
 
-	public function getApplicableDiffProvider() {
+	public function getApplicableDiffProvider(): array {
 		// Diff, current object, expected
-		$argLists = array();
+		$argLists = [];
 
-		$diff = new Diff( array(), true );
-		$currentObject = array();
+		$diff = new Diff([], true);
+		$currentObject = [];
 		$expected = clone $diff;
 
-		$argLists[] = array( $diff, $currentObject, $expected, 'Empty diff should remain empty on empty base' );
+		$argLists[] = [$diff, $currentObject, $expected, 'Empty diff should remain empty on empty base'];
 
-		$diff = new Diff( array(), true );
+		$diff = new Diff([], true);
 
-		$currentObject = array( 'foo' => 0, 'bar' => 1 );
-
-		$expected = clone $diff;
-
-		$argLists[] = array( $diff, $currentObject, $expected, 'Empty diff should remain empty on non-empty base' );
-
-		$diff = new Diff( array(
-			'foo' => new DiffOpChange( 0, 42 ),
-			'bar' => new DiffOpChange( 1, 9001 ),
-		), true );
-
-		$currentObject = array( 'foo' => 0, 'bar' => 1 );
+		$currentObject = ['foo' => 0, 'bar' => 1];
 
 		$expected = clone $diff;
 
-		$argLists[] = array( $diff, $currentObject, $expected, 'Diff should not be altered on matching base' );
+		$argLists[] = [$diff, $currentObject, $expected, 'Empty diff should remain empty on non-empty base'];
 
-		$diff = new Diff( array(
-			'foo' => new DiffOpChange( 0, 42 ),
-			'bar' => new DiffOpChange( 1, 9001 ),
-		), true );
-		$currentObject = array();
+		$diff = new Diff(
+			[
+				'foo' => new DiffOpChange(0, 42),
+				'bar' => new DiffOpChange(1, 9001),
+			],
+			true
+		);
 
-		$expected = new Diff( array(), true );
+		$currentObject = ['foo' => 0, 'bar' => 1];
 
-		$argLists[] = array( $diff, $currentObject, $expected, 'Diff with only change ops should be empty on empty base' );
+		$expected = clone $diff;
 
-		$diff = new Diff( array(
-			'foo' => new DiffOpChange( 0, 42 ),
-			'bar' => new DiffOpChange( 1, 9001 ),
-		), true );
+		$argLists[] = [$diff, $currentObject, $expected, 'Diff should not be altered on matching base'];
 
-		$currentObject = array( 'foo' => 'something else', 'bar' => 1, 'baz' => 'o_O' );
+		$diff = new Diff(
+			[
+				'foo' => new DiffOpChange(0, 42),
+				'bar' => new DiffOpChange(1, 9001),
+			],
+			true
+		);
+		$currentObject = [];
 
-		$expected = new Diff( array(
-			'bar' => new DiffOpChange( 1, 9001 ),
-		), true );
+		$expected = new Diff([], true);
 
-		$argLists[] = array( $diff, $currentObject, $expected, 'Only change ops present in the base should be retained' );
+		$argLists[] = [$diff, $currentObject, $expected, 'Diff with only change ops should be empty on empty base'];
 
-		$diff = new Diff( array(
-			'bar' => new DiffOpRemove( 9001 ),
-		), true );
+		$diff = new Diff(
+			[
+				'foo' => new DiffOpChange(0, 42),
+				'bar' => new DiffOpChange(1, 9001),
+			],
+			true
+		);
 
-		$currentObject = array();
+		$currentObject = ['foo' => 'something else', 'bar' => 1, 'baz' => 'o_O'];
 
-		$expected = new Diff( array(), true );
+		$expected = new Diff(
+			[
+				'bar' => new DiffOpChange(1, 9001),
+			],
+			true
+		);
 
-		$argLists[] = array( $diff, $currentObject, $expected, 'Remove ops should be removed on empty base' );
+		$argLists[] = [$diff, $currentObject, $expected, 'Only change ops present in the base should be retained'];
 
-		$diff = new Diff( array(
-			'foo' => new DiffOpAdd( 42 ),
-			'bar' => new DiffOpRemove( 9001 ),
-		), true );
+		$diff = new Diff(
+			[
+				'bar' => new DiffOpRemove(9001),
+			],
+			true
+		);
 
-		$currentObject = array( 'foo' => 'bar' );
+		$currentObject = [];
 
-		$expected = new Diff( array(), true );
+		$expected = new Diff([], true);
 
-		$argLists[] = array(
+		$argLists[] = [$diff, $currentObject, $expected, 'Remove ops should be removed on empty base'];
+
+		$diff = new Diff(
+			[
+				'foo' => new DiffOpAdd(42),
+				'bar' => new DiffOpRemove(9001),
+			],
+			true
+		);
+
+		$currentObject = ['foo' => 'bar'];
+
+		$expected = new Diff([], true);
+
+		$argLists[] = [
 			$diff,
 			$currentObject,
 			$expected,
-			'Mismatching add ops and remove ops not present in base should be removed'
+			'Mismatching add ops and remove ops not present in base should be removed',
+		];
+
+		$diff = new Diff(
+			[
+				'foo' => new DiffOpAdd(42),
+				'bar' => new DiffOpRemove(9001),
+			],
+			true
 		);
 
-		$diff = new Diff( array(
-			'foo' => new DiffOpAdd( 42 ),
-			'bar' => new DiffOpRemove( 9001 ),
-		), true );
+		$currentObject = ['foo' => 42, 'bar' => 9001];
 
-		$currentObject = array( 'foo' => 42, 'bar' => 9001 );
+		$expected = new Diff(
+			[
+				'bar' => new DiffOpRemove(9001),
+			],
+			true
+		);
 
-		$expected = new Diff( array(
-			'bar' => new DiffOpRemove( 9001 ),
-		), true );
+		$argLists[] = [$diff, $currentObject, $expected, 'Remove ops present in base should be retained'];
 
-		$argLists[] = array( $diff, $currentObject, $expected, 'Remove ops present in base should be retained' );
+		$diff = new Diff(
+			[
+				'foo' => new DiffOpAdd(42),
+				'bar' => new DiffOpRemove(9001),
+			],
+			true
+		);
 
-		$diff = new Diff( array(
-			'foo' => new DiffOpAdd( 42 ),
-			'bar' => new DiffOpRemove( 9001 ),
-		), true );
+		$currentObject = [];
 
-		$currentObject = array();
+		$expected = new Diff(
+			[
+				'foo' => new DiffOpAdd(42),
+			],
+			true
+		);
 
-		$expected = new Diff( array(
-			'foo' => new DiffOpAdd( 42 ),
-		), true );
-
-		$argLists[] = array(
+		$argLists[] = [
 			$diff,
 			$currentObject,
 			$expected,
-			'Add ops not present in the base should be retained (MapDiff)'
+			'Add ops not present in the base should be retained (MapDiff)',
+		];
+
+		$diff = new Diff(
+			[
+				'foo' => new Diff(['bar' => new DiffOpChange(0, 1)], true),
+				'le-non-existing-element' => new Diff(['bar' => new DiffOpChange(0, 1)], true),
+				'spam' => new Diff([new DiffOpAdd(42)], false),
+				new DiffOpAdd(9001),
+			],
+			true
 		);
 
-		$diff = new Diff( array(
-			'foo' => new Diff( array( 'bar' => new DiffOpChange( 0, 1 ) ), true ),
-			'le-non-existing-element' => new Diff( array( 'bar' => new DiffOpChange( 0, 1 ) ), true ),
-			'spam' => new Diff( array( new DiffOpAdd( 42 ) ), false ),
-			new DiffOpAdd( 9001 ),
-		), true );
+		$currentObject = [
+			'foo' => ['bar' => 0, 'baz' => 'O_o'],
+			'spam' => [23, 'ohi'],
+		];
 
-		$currentObject = array(
-			'foo' => array( 'bar' => 0, 'baz' => 'O_o' ),
-			'spam' => array( 23, 'ohi' )
+		$expected = new Diff(
+			[
+				'foo' => new Diff(['bar' => new DiffOpChange(0, 1)], true),
+				'spam' => new Diff([new DiffOpAdd(42)], false),
+				new DiffOpAdd(9001),
+			],
+			true
 		);
 
-		$expected = new Diff( array(
-			'foo' => new Diff( array( 'bar' => new DiffOpChange( 0, 1 ) ), true ),
-			'spam' => new Diff( array( new DiffOpAdd( 42 ) ), false ),
-			new DiffOpAdd( 9001 ),
-		), true );
-
-		$argLists[] = array( $diff, $currentObject, $expected, 'Recursion should work properly' );
+		$argLists[] = [$diff, $currentObject, $expected, 'Recursion should work properly'];
 
 		return $argLists;
 	}
@@ -363,84 +426,97 @@ class MapPatcherTest extends DiffTestCase {
 	/**
 	 * @dataProvider getApplicableDiffProvider
 	 *
-	 * @param Diff $diff
-	 * @param array $currentObject
-	 * @param Diff $expected
+	 * @param Diff        $diff
+	 * @param array       $currentObject
+	 * @param Diff        $expected
 	 * @param string|null $message
 	 */
-	public function testGetApplicableDiff( Diff $diff, array $currentObject, Diff $expected, $message = null ) {
+	public function testGetApplicableDiff(
+		Diff $diff,
+		array $currentObject,
+		Diff $expected,
+		?string $message = null
+	): void {
 		$patcher = new MapPatcher();
-		$actual = $patcher->getApplicableDiff( $currentObject, $diff );
+		$actual = $patcher->getApplicableDiff($currentObject, $diff);
 
-		$this->assertEquals( $expected->getOperations(), $actual->getOperations(), $message );
+		$this->assertEquals($expected->getOperations(), $actual->getOperations(), $message);
 	}
 
-	public function testSetValueComparerToAlwaysFalse() {
+	public function testSetValueComparerToAlwaysFalse(): void {
 		$patcher = new MapPatcher();
 
-		$patcher->setValueComparer( new CallbackComparer( function() {
-			return false;
-		} ) );
-
-		$baseMap = array(
-			'foo' => 42,
-			'bar' => 9001,
+		$patcher->setValueComparer(
+			new CallbackComparer(function () {
+				return false;
+			})
 		);
 
-		$patch = new Diff( array(
-			'foo' => new DiffOpChange( 42, 1337 ),
-			'bar' => new DiffOpChange( 9001, 1337 ),
-		) );
+		$baseMap = [
+			'foo' => 42,
+			'bar' => 9001,
+		];
 
-		$patchedMap = $patcher->patch( $baseMap, $patch );
+		$patch = new Diff(
+			[
+				'foo' => new DiffOpChange(42, 1337),
+				'bar' => new DiffOpChange(9001, 1337),
+			]
+		);
 
-		$this->assertEquals( $baseMap, $patchedMap );
+		$patchedMap = $patcher->patch($baseMap, $patch);
+
+		$this->assertEquals($baseMap, $patchedMap);
 	}
 
-	public function testSetValueComparerToAlwaysTrue() {
+	public function testSetValueComparerToAlwaysTrue(): void {
 		$patcher = new MapPatcher();
 
-		$patcher->setValueComparer( new CallbackComparer( function() {
-			return true;
-		} ) );
-
-		$baseMap = array(
-			'foo' => 42,
-			'bar' => 9001,
+		$patcher->setValueComparer(
+			new CallbackComparer(function () {
+				return true;
+			})
 		);
 
-		$patch = new Diff( array(
-			'foo' => new DiffOpChange( 3, 1337 ),
-			'bar' => new DiffOpChange( 3, 1337 ),
-		) );
+		$baseMap = [
+			'foo' => 42,
+			'bar' => 9001,
+		];
 
-		$expectedMap = array(
+		$patch = new Diff(
+			[
+				'foo' => new DiffOpChange(3, 1337),
+				'bar' => new DiffOpChange(3, 1337),
+			]
+		);
+
+		$expectedMap = [
 			'foo' => 1337,
 			'bar' => 1337,
-		);
+		];
 
-		$patchedMap = $patcher->patch( $baseMap, $patch );
+		$patchedMap = $patcher->patch($baseMap, $patch);
 
-		$this->assertEquals( $expectedMap, $patchedMap );
+		$this->assertEquals($expectedMap, $patchedMap);
 	}
 
-	public function testErrorOnUnknownDiffOpType() {
+	public function testErrorOnUnknownDiffOpType(): void {
 		$patcher = new MapPatcher();
 
-		$diffOp = $this->createMock( 'Diff\DiffOp\DiffOp' );
+		$diffOp = $this->createMock('Diff\DiffOp\DiffOp');
 
-		$diffOp->expects( $this->any() )
-			->method( 'getType' )
-			->will( $this->returnValue( 'diff' ) );
+		$diffOp->expects($this->any())
+			->method('getType')
+			->will($this->returnValue('diff'));
 
-		$diff = new Diff( array( $diffOp ), true );
+		$diff = new Diff([$diffOp], true);
 
-		$patcher->patch( array(), $diff );
+		$patcher->patch([], $diff);
 
 		$patcher->throwErrors();
-		$this->expectException( 'Diff\Patcher\PatcherException' );
+		$this->expectException('Diff\Patcher\PatcherException');
 
-		$patcher->patch( array(), $diff );
+		$patcher->patch([], $diff);
 	}
 
 }

--- a/tests/unit/Patcher/ThrowingPatcherTest.php
+++ b/tests/unit/Patcher/ThrowingPatcherTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace Diff\Tests\Patcher;
 
@@ -9,39 +9,39 @@ use Diff\Tests\DiffTestCase;
 use ReflectionClass;
 
 /**
- * @covers \Diff\Patcher\ThrowingPatcher
+ * @covers  \Diff\Patcher\ThrowingPatcher
  *
- * @group Diff
- * @group DiffPatcher
+ * @group   Diff
+ * @group   DiffPatcher
  *
  * @license BSD-3-Clause
- * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author  Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class ThrowingPatcherTest extends DiffTestCase {
 
-	public function testChangeThrowErrors() {
+	public function testChangeThrowErrors(): void {
 		/**
 		 * @var ThrowingPatcher $patcher
 		 */
-		$patcher = $this->getMockForAbstractClass( 'Diff\Patcher\ThrowingPatcher' );
+		$patcher = $this->getMockForAbstractClass('Diff\Patcher\ThrowingPatcher');
 
-		$class = new ReflectionClass( 'Diff\Patcher\ThrowingPatcher' );
-		$method = $class->getMethod( 'handleError' );
-		$method->setAccessible( true );
+		$class = new ReflectionClass('Diff\Patcher\ThrowingPatcher');
+		$method = $class->getMethod('handleError');
+		$method->setAccessible(true);
 
 		$errorMessage = 'foo bar';
 
-		$method->invokeArgs( $patcher, array( $errorMessage ) );
+		$method->invokeArgs($patcher, [$errorMessage]);
 
 		$patcher->throwErrors();
 		$patcher->ignoreErrors();
 
-		$method->invokeArgs( $patcher, array( $errorMessage ) );
+		$method->invokeArgs($patcher, [$errorMessage]);
 
 		$patcher->throwErrors();
-		$this->expectException( 'Diff\Patcher\PatcherException' );
+		$this->expectException('Diff\Patcher\PatcherException');
 
-		$method->invokeArgs( $patcher, array( $errorMessage ) );
+		$method->invokeArgs($patcher, [$errorMessage]);
 	}
 
 }


### PR DESCRIPTION
In the scope of this PR, the support for PHP 8.1 is added (deprecated Serializable interface is removed). Since php 7.2 and 7.3 are no supported anymore, the support for them is removed in this PR.