### PR TITLE
Add PHP 8.1 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ install: travis_retry composer install --prefer-source
 script: composer ci
 
 after_success:
-  - if [[ "`phpenv version-name`" != "8.1" ]]; then exit 0; fi
-  - vendor/bin/phpunit --coverage-clover coverage.clover
+  - if [[ "`phpenv version-name`" != "7.4" ]]; then exit 0; fi
+  - XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-clover coverage.clover
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 7.3
   - 7.4
   - 8.0
+  - 8.1.2
 
 sudo: false
 
@@ -13,7 +14,7 @@ install: travis_retry composer install --prefer-source
 script: composer ci
 
 after_success:
-  - if [[ "`phpenv version-name`" != "8.0" ]]; then exit 0; fi
+  - if [[ "`phpenv version-name`" != "8.1" ]]; then exit 0; fi
   - vendor/bin/phpunit --coverage-clover coverage.clover
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/Diff.php
+++ b/Diff.php
@@ -10,4 +10,4 @@ if ( defined( 'Diff_VERSION' ) ) {
 /**
  * @deprecated Will be removed in 4.0
  */
-define( 'Diff_VERSION', '3.2' );
+define( 'Diff_VERSION', '3.3' );

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A full history of the different versions of Diff can be found in the [release no
 
 **Diff 3.x:**
 
-* PHP 7.0 or later (tested with PHP 7.0 up to PHP 7.4)
+* PHP 7.2 or later (tested with PHP 7.2 up to PHP 8.1)
 
 **Diff 2.x:**
 

--- a/src/DiffOp/Diff/Diff.php
+++ b/src/DiffOp/Diff/Diff.php
@@ -145,21 +145,29 @@ class Diff extends ArrayObject implements DiffOp {
 	 *
 	 * @param string $serialization
 	 */
+	#[\ReturnTypeWillChange]
 	public function unserialize( $serialization ) {
-		$serializationData = unserialize( $serialization );
+		$this->__unserialize( unserialize( $serialization) );
+	}
 
-		foreach ( $serializationData['data'] as $offset => $value ) {
+	/**
+	 * @since 3.3.0
+	 *
+	 * @param array $data
+	 */
+	public function __unserialize( array $data ): void {
+		foreach ( $data['data'] as $offset => $value ) {
 			// Just set the element, bypassing checks and offset resolving,
 			// as these elements have already gone through this.
 			parent::offsetSet( $offset, $value );
 		}
 
-		$this->indexOffset = $serializationData['index'];
+		$this->indexOffset = $data['index'];
 
-		$this->typePointers = $serializationData['typePointers'];
+		$this->typePointers = $data['typePointers'];
 
-		if ( array_key_exists( 'assoc', $serializationData ) ) {
-			$this->isAssociative = $serializationData['assoc'] === 'n' ? null : $serializationData['assoc'] === 't';
+		if ( array_key_exists( 'assoc', $data ) ) {
+			$this->isAssociative = $data['assoc'] === 'n' ? null : $data['assoc'] === 't';
 		}
 	}
 
@@ -383,6 +391,7 @@ class Diff extends ArrayObject implements DiffOp {
 	 *
 	 * @param mixed $value
 	 */
+	#[\ReturnTypeWillChange]
 	public function append( $value ) {
 		$this->setElement( null, $value );
 	}
@@ -395,6 +404,7 @@ class Diff extends ArrayObject implements DiffOp {
 	 * @param int|string $index
 	 * @param mixed $value
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetSet( $index, $value ) {
 		$this->setElement( $index, $value );
 	}
@@ -436,17 +446,25 @@ class Diff extends ArrayObject implements DiffOp {
 	 *
 	 * @return string
 	 */
+	#[\ReturnTypeWillChange]
 	public function serialize() {
+		return serialize( $this->__serialize() );
+	}
+
+	/**
+	 * @since 3.3.0
+	 *
+	 * @return array
+	 */
+	public function __serialize(): array {
 		$assoc = $this->isAssociative === null ? 'n' : ( $this->isAssociative ? 't' : 'f' );
 
-		$data = [
+		return [
 			'data' => $this->getArrayCopy(),
 			'index' => $this->indexOffset,
 			'typePointers' => $this->typePointers,
 			'assoc' => $assoc
 		];
-
-		return serialize( $data );
 	}
 
 	/**

--- a/src/DiffOp/DiffOpAdd.php
+++ b/src/DiffOp/DiffOpAdd.php
@@ -55,7 +55,7 @@ class DiffOpAdd extends AtomicDiffOp {
 	 */
 	#[\ReturnTypeWillChange]
 	public function serialize() {
-		return serialize( $this->__serialize() );
+		return serialize( $this->newValue );
 	}
 
 	/**
@@ -76,7 +76,7 @@ class DiffOpAdd extends AtomicDiffOp {
 	 */
 	#[\ReturnTypeWillChange]
 	public function unserialize( $serialization ) {
-		$this->__unserialize( unserialize ($serialization) );
+		$this->newValue = unserialize( $serialization );
 	}
 
 	/**

--- a/src/DiffOp/DiffOpAdd.php
+++ b/src/DiffOp/DiffOpAdd.php
@@ -53,8 +53,18 @@ class DiffOpAdd extends AtomicDiffOp {
 	 *
 	 * @return string|null
 	 */
+	#[\ReturnTypeWillChange]
 	public function serialize() {
-		return serialize( $this->newValue );
+		return serialize( $this->__serialize() );
+	}
+
+	/**
+	 * @since 3.3.0
+	 *
+	 * @return array
+	 */
+	public function __serialize(): array {
+		return [ $this->newValue ];
 	}
 
 	/**
@@ -64,8 +74,18 @@ class DiffOpAdd extends AtomicDiffOp {
 	 *
 	 * @param string $serialization
 	 */
+	#[\ReturnTypeWillChange]
 	public function unserialize( $serialization ) {
-		$this->newValue = unserialize( $serialization );
+		$this->__unserialize( unserialize ($serialization) );
+	}
+
+	/**
+	 * @since 3.3.0
+	 *
+	 * @param array $data
+	 */
+	public function __unserialize( array $data ): void {
+		[ $this->newValue ] = $data;
 	}
 
 	/**

--- a/src/DiffOp/DiffOpChange.php
+++ b/src/DiffOp/DiffOpChange.php
@@ -65,8 +65,18 @@ class DiffOpChange extends AtomicDiffOp {
 	 *
 	 * @return string|null
 	 */
+	#[\ReturnTypeWillChange]
 	public function serialize() {
-		return serialize( [ $this->newValue, $this->oldValue ] );
+		return serialize( $this->__serialize() );
+	}
+
+	/**
+	 * @since 3.3.0
+	 *
+	 * @return array
+	 */
+	public function __serialize(): array {
+		return [ $this->newValue, $this->oldValue ];
 	}
 
 	/**
@@ -76,8 +86,18 @@ class DiffOpChange extends AtomicDiffOp {
 	 *
 	 * @param string $serialization
 	 */
+	#[\ReturnTypeWillChange]
 	public function unserialize( $serialization ) {
-		list( $this->newValue, $this->oldValue ) = unserialize( $serialization );
+		$this->__unserialize( unserialize ($serialization) );
+	}
+
+	/**
+	 * @since 3.3.0
+	 *
+	 * @param array $data
+	 */
+	public function __unserialize( array $data ): void {
+		[ $this->newValue, $this->oldValue ] = $data;
 	}
 
 	/**

--- a/src/DiffOp/DiffOpRemove.php
+++ b/src/DiffOp/DiffOpRemove.php
@@ -53,8 +53,18 @@ class DiffOpRemove extends AtomicDiffOp {
 	 *
 	 * @return string|null
 	 */
+	#[\ReturnTypeWillChange]
 	public function serialize() {
-		return serialize( $this->oldValue );
+		return serialize( $this->__serialize() );
+	}
+
+	/**
+	 * @since 3.3.0
+	 *
+	 * @return array
+	 */
+	public function __serialize(): array {
+		return [ $this->oldValue ];
 	}
 
 	/**
@@ -64,8 +74,18 @@ class DiffOpRemove extends AtomicDiffOp {
 	 *
 	 * @param string $serialization
 	 */
+	#[\ReturnTypeWillChange]
 	public function unserialize( $serialization ) {
-		$this->oldValue = unserialize( $serialization );
+		$this->__unserialize( unserialize ($serialization) );
+	}
+
+	/**
+	 * @since 3.3.0
+	 *
+	 * @param array $data
+	 */
+	public function __unserialize( array $data ): void {
+		[ $this->oldValue ] = $data;
 	}
 
 	/**

--- a/src/DiffOp/DiffOpRemove.php
+++ b/src/DiffOp/DiffOpRemove.php
@@ -55,7 +55,7 @@ class DiffOpRemove extends AtomicDiffOp {
 	 */
 	#[\ReturnTypeWillChange]
 	public function serialize() {
-		return serialize( $this->__serialize() );
+		return serialize( $this->oldValue );
 	}
 
 	/**
@@ -76,7 +76,7 @@ class DiffOpRemove extends AtomicDiffOp {
 	 */
 	#[\ReturnTypeWillChange]
 	public function unserialize( $serialization ) {
-		$this->__unserialize( unserialize ($serialization) );
+		$this->oldValue = unserialize( $serialization );
 	}
 
 	/**

--- a/tests/unit/DiffOp/Diff/DiffTest.php
+++ b/tests/unit/DiffOp/Diff/DiffTest.php
@@ -479,7 +479,7 @@ class DiffTest extends DiffTestCase {
 	 * @param Diff $list
 	 */
 	public function testAddInvalidDiffOp( Diff $list ) {
-		$invalidDiffOp = $this->createMock( 'Diff\DiffOp\DiffOp' );
+		$invalidDiffOp = $this->createMock( DiffOpRemove::class );
 
 		$invalidDiffOp->expects( $this->atLeastOnce() )
 			->method( 'getType' )

--- a/tests/unit/DiffOp/DiffOpTest.php
+++ b/tests/unit/DiffOp/DiffOpTest.php
@@ -116,6 +116,19 @@ abstract class DiffOpTest extends DiffTestCase {
 	/**
 	 * @dataProvider instanceProvider
 	 */
+	public function testLegacySerializationCompatibility( DiffOp $diffOp ) {
+		$innerSerialization = $diffOp->serialize();
+		$legacySerialization = 'C:' . strlen( get_class( $diffOp ) ) . ':"' . get_class( $diffOp ) .
+			'":' . strlen( $innerSerialization ) . ':{' . $innerSerialization . '}';
+
+		$unserialization = unserialize( $legacySerialization );
+		$this->assertEquals( $diffOp, $unserialization );
+		$this->assertEquals( serialize( $diffOp ), serialize( $unserialization ) );
+	}
+
+	/**
+	 * @dataProvider instanceProvider
+	 */
 	public function testCount( DiffOp $diffOp ) {
 		if ( $diffOp->isAtomic() ) {
 			$this->assertSame( 1, $diffOp->count() );

--- a/tests/unit/Patcher/MapPatcherTest.php
+++ b/tests/unit/Patcher/MapPatcherTest.php
@@ -427,7 +427,7 @@ class MapPatcherTest extends DiffTestCase {
 	public function testErrorOnUnknownDiffOpType() {
 		$patcher = new MapPatcher();
 
-		$diffOp = $this->createMock( 'Diff\DiffOp\DiffOp' );
+		$diffOp = $this->createMock( DiffOpRemove::class );
 
 		$diffOp->expects( $this->any() )
 			->method( 'getType' )


### PR DESCRIPTION
Contains #129, one additional backwards compatibility fix and silences some deprecation notices from us mocking the `DiffOp` interface.

Tested with `PHP 8.1.10`.