### PR TITLE
Make our __unserialize declarations match PHP 7's

### DIFF
--- a/src/DiffOp/Diff/Diff.php
+++ b/src/DiffOp/Diff/Diff.php
@@ -155,7 +155,7 @@ class Diff extends ArrayObject implements DiffOp {
 	 *
 	 * @param array $data
 	 */
-	public function __unserialize( array $data ): void {
+	public function __unserialize( $data ): void {
 		foreach ( $data['data'] as $offset => $value ) {
 			// Just set the element, bypassing checks and offset resolving,
 			// as these elements have already gone through this.

--- a/src/DiffOp/DiffOpAdd.php
+++ b/src/DiffOp/DiffOpAdd.php
@@ -84,7 +84,7 @@ class DiffOpAdd extends AtomicDiffOp {
 	 *
 	 * @param array $data
 	 */
-	public function __unserialize( array $data ): void {
+	public function __unserialize( $data ): void {
 		[ $this->newValue ] = $data;
 	}
 

--- a/src/DiffOp/DiffOpChange.php
+++ b/src/DiffOp/DiffOpChange.php
@@ -96,7 +96,7 @@ class DiffOpChange extends AtomicDiffOp {
 	 *
 	 * @param array $data
 	 */
-	public function __unserialize( array $data ): void {
+	public function __unserialize( $data ): void {
 		[ $this->newValue, $this->oldValue ] = $data;
 	}
 

--- a/src/DiffOp/DiffOpRemove.php
+++ b/src/DiffOp/DiffOpRemove.php
@@ -84,7 +84,7 @@ class DiffOpRemove extends AtomicDiffOp {
 	 *
 	 * @param array $data
 	 */
-	public function __unserialize( array $data ): void {
+	public function __unserialize( $data ): void {
 		[ $this->oldValue ] = $data;
 	}
 


### PR DESCRIPTION
PHP 7 seems to have the method declared without the type hint and return type, causing warnings.