### PR TITLE
fix deprecation warnings

### DIFF
--- a/src/DiffOp/Diff/Diff.php
+++ b/src/DiffOp/Diff/Diff.php
@@ -144,6 +144,8 @@ class Diff extends ArrayObject implements DiffOp {
 	 * @since 0.1
 	 *
 	 * @param string $serialization
+	 * 
+	 * @return void
 	 */
 	#[\ReturnTypeWillChange]
 	public function unserialize( $serialization ) {
@@ -390,6 +392,8 @@ class Diff extends ArrayObject implements DiffOp {
 	 * @since 0.1
 	 *
 	 * @param mixed $value
+	 * 
+	 * @return void
 	 */
 	#[\ReturnTypeWillChange]
 	public function append( $value ) {
@@ -403,6 +407,8 @@ class Diff extends ArrayObject implements DiffOp {
 	 *
 	 * @param int|string $index
 	 * @param mixed $value
+	 * 
+	 * @return void
 	 */
 	#[\ReturnTypeWillChange]
 	public function offsetSet( $index, $value ) {


### PR DESCRIPTION
Some analyzers (e.g. Symfony DebugClassLoader) advise to add @return annotation along with #[ReturnTypeWillChange]:

> "User Deprecated: Method "ArrayObject::unserialize()" might add "void" as a native return type declaration in the future. Do the same in child class "Diff\DiffOp\Diff\Diff" now to avoid errors or add an explicit @return annotation to suppress this message."