### PR TITLE
Added github actions workflow to lint and test when pushing code

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,0 +1,28 @@
+name: Lint and Test
+on: push
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php_version: [ '7.2', '7.3', '7.4', '8.0', '8.1' ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php_version }}
+      - name: Validate composer.json and composer.lock
+        run: composer validate --strict
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v3
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ matrix.php_version}}-${{ hashFiles('**/composer.lock') }}
+      - name: Install dependencies
+        run: composer install --prefer-source --no-progress
+      - name: Run test suite
+        run: composer run-script ci


### PR DESCRIPTION
Initial workflow definition. Still to be added (to be in par with the existing travis CI build) are code coverage generation and publishing the results for scrutinizer, and sending notifications (email instead of IRC?) on, at least, failed runs