### PR TITLE
GitHub actions email on failure

### DIFF
--- a/.github/workflows/ci_failure_email.md.tmpl
+++ b/.github/workflows/ci_failure_email.md.tmpl
@@ -1,0 +1,3 @@
+CI workflow ${WORKFLOW} failed!
+
+The failed job can be found in [here](${SERVER_URL}/${REPOSITORY}/actions/runs/${RUN_ID}).

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -14,6 +14,15 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php_version }}
+      - uses: nowactions/envsubst@v1
+        with:
+          input: ${{ github.workspace }}/.github/workflows/ci_failure_email.md.tmpl
+          output: ${{ github.workspace }}/.github/workflows/ci_failure_email.md
+        env:
+          WORKFLOW: ${{ github.workflow }}
+          SERVER_URL: ${{ github.server_url }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
       - name: Validate composer.json and composer.lock
         run: composer validate --strict
       - name: Cache Composer packages
@@ -37,6 +46,5 @@ jobs:
           to: wikidata-ci-status@wikimedia.de
           from: ${{ github.repository }} CI
           subject: CI job failed for ${{ github.repository }}
-          html_body: |
-            CI workflow ${{ github.workflow }} failed!
-            The failed job can be found in <a href="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}">here</a>
+          convert_markdown: true
+          html_body: file://${{ github.workspace }}/.github/workflows/ci_failure_email.md

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -26,3 +26,17 @@ jobs:
         run: composer install --prefer-source --no-progress
       - name: Run test suite
         run: composer run-script ci
+      - name: Send mail on failure
+        if: ${{ failure() }}
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: smtp.gmail.com
+          server_port: 465
+          username: ${{secrets.CI_MAIL_USERNAME}}
+          password: ${{secrets.CI_MAIL_PASSWORD}}
+          to: wikidata-ci-status@wikimedia.de
+          from: ${{ github.repository }} CI
+          subject: CI job failed for ${{ github.repository }}
+          html_body: |
+            CI workflow ${{ github.workflow }} failed!
+            The failed job can be found in <a href="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}">here</a>


### PR DESCRIPTION
Further work to move over from Travis CI.
Includes the commit from https://github.com/wmde/Diff/pull/138

Relevant commit for emails on failure is dc3b2b9605e018ffea5ad16c007ffe3035b8072e and following ones