### PR TITLE
Bump version to 3.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A full history of the different versions of Diff can be found in the [release no
 
 **Diff 3.x:**
 
-* PHP 7.2 or later (tested with PHP 7.2 up to PHP 8.1)
+* PHP 7.2 or later (tested with PHP 7.4 up to PHP 8.4)
 
 **Diff 2.x:**
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,6 +3,12 @@ These are the release notes for the [Diff library](README.md).
 Latest release:
 [![Latest Stable Version](https://poser.pugx.org/diff/diff/version.png)](https://packagist.org/packages/diff/diff)
 
+## Version 3.4.0 (2024-12-12)
+
+* Drop support for PHP 7.2, 7.3
+* Upgrade codesniffer rules to current `mediawiki/mediawiki-codesniffer` version (45.0.0)
+* Make nullable type parameter declarations explicit for compatibility with PHP 8.4
+
 ## Version 3.3.1 (2022-10-06)
 
 * Made our __unserialize declarations match PHP 7's, to avoid PHP warnings


### PR DESCRIPTION
 * Drop support for PHP 7.2, 7.3
 * Upgrade codesniffer rules to current `mediawiki/mediawiki-codesniffer` version (45.0.0)
 * Make nullable type parameter declarations explicit for compatibility with PHP 8.4

Bug: T379481